### PR TITLE
use criterion for benchmarks

### DIFF
--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -58,6 +58,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "atoi_radix10"
 version = "0.0.1"
 source = "git+https://github.com/gilescope/atoi_radix10#b1d6e6c1009f0971efebfa55a61b6cb7c0b5d641"
@@ -339,6 +345,7 @@ name = "ferris-elf"
 version = "0.0.0"
 dependencies = [
  "arrayvec",
+ "ascii",
  "atoi_radix10",
  "bitvec",
  "btoi",

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -3,6 +3,34 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +38,18 @@ checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "arrayvec"
@@ -29,10 +69,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
@@ -56,10 +117,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
 name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -68,9 +150,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
 name = "core_simd"
 version = "0.1.0"
 source = "git+https://github.com/rust-lang/portable-simd#e0e9a4517f9fc021283514da387e70a56061bd3e"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -119,10 +298,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ferris-elf"
@@ -134,15 +344,29 @@ dependencies = [
  "btoi",
  "bytemuck",
  "core_simd",
+ "criterion",
  "dashmap",
  "itertools",
  "memchr",
  "nom",
  "parse-display",
+ "pprof",
  "rayon",
  "regex",
  "rustc-hash",
  "smallvec",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -152,10 +376,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "inferno"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "itertools"
@@ -167,10 +459,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "js-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
@@ -183,10 +502,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "memmap2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -204,6 +538,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +565,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -223,10 +587,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "parking_lot_core"
@@ -238,7 +627,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -264,7 +653,57 @@ dependencies = [
  "regex",
  "regex-syntax 0.6.29",
  "structmeta",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "criterion",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -274,6 +713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -317,7 +765,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -356,10 +804,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rgb"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -368,10 +859,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "structmeta"
@@ -382,7 +916,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -393,7 +927,30 @@ checksum = "24420be405b590e2d746d83b01f09af673270cf80e9b003a5fa7b651c58c7d93"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cccfffbc6bb3bb2d3a26cd2077f4d055f6808d266f9d4d158797a4c60510dfe"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a99812da4020a67e76c4eb41f08c87364c14170495ff780f30dd519c221a68"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
 ]
 
 [[package]]
@@ -408,10 +965,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -420,18 +1031,174 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "uuid"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -441,10 +1208,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -453,10 +1232,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -465,10 +1256,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -477,10 +1280,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -20,3 +20,10 @@ atoi_radix10 = { git = "https://github.com/gilescope/atoi_radix10" }
 btoi = "0.4"
 nom = "7"
 
+[dev-dependencies]
+criterion = { version = "0.5.1" }
+pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -19,6 +19,7 @@ dashmap = "5"
 atoi_radix10 = { git = "https://github.com/gilescope/atoi_radix10" }
 btoi = "0.4"
 nom = "7"
+ascii = "1.1.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1" }

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,6 +1,8 @@
-from rust:latest
+FROM rust:latest
 RUN rustup install nightly
 RUN rustup default nightly
+# We need this to get JSON output from cargo criterion
+RUN cargo install --version=1.0.0-alpha3 cargo-criterion
 ENV RUSTFLAGS="-C target-cpu=native"
 ENV CARGO_TERM_COLOR="never"
 ENV TERM="dumb"

--- a/runner/benches/bench.rs
+++ b/runner/benches/bench.rs
@@ -1,0 +1,27 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ferris_elf::aocsoln::AOCSolution;
+use ferris_elf::code;
+use pprof::criterion::{Output, PProfProfiler};
+
+//note that criterion does not allow setting hard limits on bench time
+//we have to enforce time limits outside - see the ./run_bench.sh script
+pub fn all(c: &mut Criterion) {
+    let input: &str = include_str!("../inputs/input1.txt");
+    let mut group = c.benchmark_group("part1");
+
+    group.sample_size(10);
+
+    group.bench_function("part1", |b| {
+        b.iter(|| code::Soln::aoc_part1(black_box(input.as_bytes())))
+    });
+    group.bench_function("part2", |b| {
+        b.iter(|| code::Soln::aoc_part2(black_box(input.as_bytes())))
+    });
+    group.finish();
+}
+
+criterion_group!(
+    name=benches;
+    config=Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets=all);
+criterion_main!(benches);

--- a/runner/benches/bench.rs
+++ b/runner/benches/bench.rs
@@ -8,11 +8,7 @@ pub fn all(c: &mut Criterion) {
     let input: &str = include_str!("../inputs/input1.txt");
     let mut group = c.benchmark_group("aoc_sub");
 
-    group.sample_size(10);
-
-    group.bench_function("run", |b| {
-        b.iter(|| code::Soln::run(black_box(input.as_ref())))
-    });
+    group.bench_function("run", |b| b.iter(|| code::run(black_box(input.as_ref()))));
     group.finish();
 }
 

--- a/runner/benches/bench.rs
+++ b/runner/benches/bench.rs
@@ -1,5 +1,4 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ferris_elf::aocsoln::AOCSolution;
 use ferris_elf::code;
 use pprof::criterion::{Output, PProfProfiler};
 
@@ -7,15 +6,12 @@ use pprof::criterion::{Output, PProfProfiler};
 //we have to enforce time limits outside - see the ./run_bench.sh script
 pub fn all(c: &mut Criterion) {
     let input: &str = include_str!("../inputs/input1.txt");
-    let mut group = c.benchmark_group("part1");
+    let mut group = c.benchmark_group("aoc_sub");
 
     group.sample_size(10);
 
-    group.bench_function("part1", |b| {
-        b.iter(|| code::Soln::aoc_part1(black_box(input.as_bytes())))
-    });
-    group.bench_function("part2", |b| {
-        b.iter(|| code::Soln::aoc_part2(black_box(input.as_bytes())))
+    group.bench_function("run", |b| {
+        b.iter(|| code::Soln::run(black_box(input.as_ref())))
     });
     group.finish();
 }

--- a/runner/run_bench.sh
+++ b/runner/run_bench.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+# this will return an exit status of 124 or 128 if the benchmark times out
+timeout --kill-after=1s 1s cargo criterion --message-format=json 1>bench_results.json

--- a/runner/src/aocsoln.rs
+++ b/runner/src/aocsoln.rs
@@ -1,0 +1,6 @@
+/// This is the interface between user solutions and our benchmarks.
+/// Solutions must implement this trait
+pub trait AOCSolution {
+    fn aoc_part1(raw_input: &[u8]) -> String;
+    fn aoc_part2(raw_input: &[u8]) -> String;
+}

--- a/runner/src/aocsoln.rs
+++ b/runner/src/aocsoln.rs
@@ -1,6 +1,0 @@
-/// This is the interface between user solutions and our benchmarks.
-/// Solutions must implement this trait
-pub trait AOCSolution {
-    fn aoc_part1(raw_input: &[u8]) -> String;
-    fn aoc_part2(raw_input: &[u8]) -> String;
-}

--- a/runner/src/code.rs
+++ b/runner/src/code.rs
@@ -11,98 +11,137 @@ pub struct Valve {
 }
 type Valves = HashMap<u16, Valve>;
 
-pub struct Soln {}
-impl Soln {
-    const AA: u16 = ((b'A' as u16) << 8) | (b'A' as u16);
+const AA: u16 = ((b'A' as u16) << 8) | (b'A' as u16);
 
-    #[inline]
-    pub fn parse(input: &str) -> Valves {
-        input
-            .lines()
-            .map(|sline| {
-                let line = sline.as_bytes();
-                // If not for the different text when a valve only has a single tunnel,
-                // this wouldn't be necessary. But the different text does three things:
-                // 1) removes an s from tunnels (net -1)
-                // 2) adds an s to lead (net 0)
-                // 3) removes an s from valves (net -1)
-                // This means that the tunnel list can start at positions:
-                // 50 => 2 digit flow value, multiple tunnels. Char 48 is always an `s`
-                // 49 => 1 digit flow value, multiple tunnels. Char 48 is always a space
-                // 49 => 2 digit flow value, one tunnel. Char 48 is always a space
-                // 48 => 1 digit flow value, one tunnel. Char 48 is a capital A-Z.
-                let tunnels = match line[48] {
-                    b's' => 50,
-                    b' ' => 49,
-                    _ => 48,
-                };
-                (
-                    line[6..8].iter().fold(0, |a, b| (a << 8) | *b as u16),
-                    Valve {
-                        rate: line[23..25].iter().fold(0, |a, b| match b {
-                            b';' => a,
-                            _ => (10 * a) + (b - b'0') as i64,
-                        }),
-                        connections: line[tunnels..]
-                            .split(|byte| b','.eq(byte) || b' '.eq(byte))
-                            .filter(|slc| slc.len() > 0)
-                            .map(|valve| valve.iter().fold(0, |a, b| (a << 8) | *b as u16))
-                            .collect(),
-                        open: false,
-                    },
-                )
-            })
-            .collect()
+#[inline]
+pub fn parse(input: &str) -> Valves {
+    input
+        .lines()
+        .map(|sline| {
+            let line = sline.as_bytes();
+            // If not for the different text when a valve only has a single tunnel,
+            // this wouldn't be necessary. But the different text does three things:
+            // 1) removes an s from tunnels (net -1)
+            // 2) adds an s to lead (net 0)
+            // 3) removes an s from valves (net -1)
+            // This means that the tunnel list can start at positions:
+            // 50 => 2 digit flow value, multiple tunnels. Char 48 is always an `s`
+            // 49 => 1 digit flow value, multiple tunnels. Char 48 is always a space
+            // 49 => 2 digit flow value, one tunnel. Char 48 is always a space
+            // 48 => 1 digit flow value, one tunnel. Char 48 is a capital A-Z.
+            let tunnels = match line[48] {
+                b's' => 50,
+                b' ' => 49,
+                _ => 48,
+            };
+            (
+                line[6..8].iter().fold(0, |a, b| (a << 8) | *b as u16),
+                Valve {
+                    rate: line[23..25].iter().fold(0, |a, b| match b {
+                        b';' => a,
+                        _ => (10 * a) + (b - b'0') as i64,
+                    }),
+                    connections: line[tunnels..]
+                        .split(|byte| b','.eq(byte) || b' '.eq(byte))
+                        .filter(|slc| slc.len() > 0)
+                        .map(|valve| valve.iter().fold(0, |a, b| (a << 8) | *b as u16))
+                        .collect(),
+                    open: false,
+                },
+            )
+        })
+        .collect()
+}
+
+pub fn double_valverun(
+    human: (u16, u16),
+    elephant: (u16, u16),
+    valves: &Valves,
+    time: i64,
+    highest: &mut HashMap<i64, i64>,
+    total: i64,
+    turnflow: i64,
+) -> i64 {
+    if time == 0 {
+        return total;
     }
 
-    pub fn double_valverun(
-        human: (u16, u16),
-        elephant: (u16, u16),
-        valves: &Valves,
-        time: i64,
-        highest: &mut HashMap<i64, i64>,
-        total: i64,
-        turnflow: i64,
-    ) -> i64 {
-        if time == 0 {
-            return total;
-        }
+    let best_time = match highest.get(&time) {
+        Some(&score) => score,
+        _ => 0,
+    };
+    // Same as p1. Works for the test input & my own input.
+    if best_time > (total + 26) {
+        return 0;
+    }
+    if total > best_time {
+        highest.insert(time, total);
+    }
 
-        let best_time = match highest.get(&time) {
-            Some(&score) => score,
-            _ => 0,
-        };
-        // Same as p1. Works for the test input & my own input.
-        if best_time > (total + 26) {
-            return 0;
-        }
-        if total > best_time {
-            highest.insert(time, total);
-        }
+    let mut curmax = total;
+    let (hum_current, hum_last) = human;
+    let (ele_current, ele_last) = elephant;
+    let mut hum_valve = valves.get(&hum_current).unwrap().clone();
+    let mut ele_valve = valves.get(&ele_current).unwrap().clone();
+    let hum_conns = hum_valve.connections.clone();
+    let ele_conns = ele_valve.connections.clone();
 
-        let mut curmax = total;
-        let (hum_current, hum_last) = human;
-        let (ele_current, ele_last) = elephant;
-        let mut hum_valve = valves.get(&hum_current).unwrap().clone();
-        let mut ele_valve = valves.get(&ele_current).unwrap().clone();
-        let hum_conns = hum_valve.connections.clone();
-        let ele_conns = ele_valve.connections.clone();
-
-        // Both closed and positive flow available? Run both!
-        if !hum_valve.open
-            && hum_valve.rate > 0
-            && !ele_valve.open
-            && ele_valve.rate > 0
-            && hum_current != ele_current
-        {
-            hum_valve.open = true;
-            ele_valve.open = true;
-            let rate = ele_valve.rate + hum_valve.rate;
-            let mut cloned = valves.clone();
-            cloned.insert(ele_current, ele_valve);
-            cloned.insert(hum_current, hum_valve);
-            curmax = curmax.max(Self::double_valverun(
+    // Both closed and positive flow available? Run both!
+    if !hum_valve.open
+        && hum_valve.rate > 0
+        && !ele_valve.open
+        && ele_valve.rate > 0
+        && hum_current != ele_current
+    {
+        hum_valve.open = true;
+        ele_valve.open = true;
+        let rate = ele_valve.rate + hum_valve.rate;
+        let mut cloned = valves.clone();
+        cloned.insert(ele_current, ele_valve);
+        cloned.insert(hum_current, hum_valve);
+        curmax = curmax.max(double_valverun(
+            (hum_current, 0),
+            (ele_current, 0),
+            &cloned,
+            time - 1,
+            highest,
+            total + turnflow,
+            turnflow + rate,
+        ));
+    }
+    // Human closed and positive flow available? Run it!
+    else if !hum_valve.open && hum_valve.rate > 0 {
+        hum_valve.open = true;
+        let rate = hum_valve.rate;
+        let mut cloned = valves.clone();
+        cloned.insert(hum_current, hum_valve);
+        for &label in &ele_conns {
+            if label == ele_last {
+                continue;
+            }
+            curmax = curmax.max(double_valverun(
                 (hum_current, 0),
+                (label, ele_current),
+                &cloned,
+                time - 1,
+                highest,
+                total + turnflow,
+                turnflow + rate,
+            ));
+        }
+    }
+    // Elephant closed and flow available? GOGOGOGOGO!
+    else if !ele_valve.open && ele_valve.rate > 0 {
+        ele_valve.open = true;
+        let rate = ele_valve.rate;
+        let mut cloned = valves.clone();
+        cloned.insert(ele_current, ele_valve);
+        for &label in &hum_conns {
+            if label == hum_last {
+                continue;
+            }
+            curmax = curmax.max(double_valverun(
+                (label, hum_current),
                 (ele_current, 0),
                 &cloned,
                 time - 1,
@@ -111,96 +150,47 @@ impl Soln {
                 turnflow + rate,
             ));
         }
-        // Human closed and positive flow available? Run it!
-        else if !hum_valve.open && hum_valve.rate > 0 {
-            hum_valve.open = true;
-            let rate = hum_valve.rate;
-            let mut cloned = valves.clone();
-            cloned.insert(hum_current, hum_valve);
-            for &label in &ele_conns {
-                if label == ele_last {
+    }
+    // Neither has more flow available, time to walk all next paths instead
+    else {
+        for hum_label in hum_conns {
+            if hum_label == hum_last {
+                continue;
+            }
+            for &ele_label in &ele_conns {
+                if ele_label == ele_last {
                     continue;
                 }
-                curmax = curmax.max(Self::double_valverun(
-                    (hum_current, 0),
-                    (label, ele_current),
-                    &cloned,
+                curmax = curmax.max(double_valverun(
+                    (hum_label, hum_current),
+                    (ele_label, ele_current),
+                    valves,
                     time - 1,
                     highest,
                     total + turnflow,
-                    turnflow + rate,
+                    turnflow,
                 ));
             }
         }
-        // Elephant closed and flow available? GOGOGOGOGO!
-        else if !ele_valve.open && ele_valve.rate > 0 {
-            ele_valve.open = true;
-            let rate = ele_valve.rate;
-            let mut cloned = valves.clone();
-            cloned.insert(ele_current, ele_valve);
-            for &label in &hum_conns {
-                if label == hum_last {
-                    continue;
-                }
-                curmax = curmax.max(Self::double_valverun(
-                    (label, hum_current),
-                    (ele_current, 0),
-                    &cloned,
-                    time - 1,
-                    highest,
-                    total + turnflow,
-                    turnflow + rate,
-                ));
-            }
-        }
-        // Neither has more flow available, time to walk all next paths instead
-        else {
-            for hum_label in hum_conns {
-                if hum_label == hum_last {
-                    continue;
-                }
-                for &ele_label in &ele_conns {
-                    if ele_label == ele_last {
-                        continue;
-                    }
-                    curmax = curmax.max(Self::double_valverun(
-                        (hum_label, hum_current),
-                        (ele_label, ele_current),
-                        valves,
-                        time - 1,
-                        highest,
-                        total + turnflow,
-                        turnflow,
-                    ));
-                }
-            }
-        }
-        curmax
     }
+    curmax
+}
 
-    #[inline]
-    pub fn part_one(parsed: &Valves) -> i64 {
-        Self::double_valverun(
-            (Self::AA, 0),
-            (Self::AA, 0),
-            parsed,
-            26,
-            &mut HashMap::new(),
-            0,
-            0,
-        )
-    }
+#[inline]
+pub fn part_one(parsed: &Valves) -> i64 {
+    double_valverun((AA, 0), (AA, 0), parsed, 26, &mut HashMap::new(), 0, 0)
+}
 
-    //These are some of the possible signatures user submitted code could have.
-    pub fn run(input: &str) -> impl Display {
-        Self::part_one(&Self::parse(input))
-    }
-    pub fn run_ascii(input: &AsciiStr) -> impl Display {
-        let input_str = input.as_str();
-        Self::run(input_str)
-    }
-    pub fn run_bytes(input: &[u8]) -> impl Display {
-        let input_str = input.as_ascii_str().unwrap();
-        Self::run_ascii(input_str)
-    }
+//These are some of the possible signatures user submitted code could have.
+//In practice there will be a single `run` function
+pub fn run(input: &str) -> impl Display {
+    part_one(&parse(input))
+}
+pub fn run_ascii(input: &AsciiStr) -> impl Display {
+    let input_str = input.as_str();
+    run(input_str)
+}
+pub fn run_bytes(input: &[u8]) -> impl Display {
+    let input_str = input.as_ascii_str().unwrap();
+    run_ascii(input_str)
 }

--- a/runner/src/code.rs
+++ b/runner/src/code.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+// structs and types cannot be part of struct impls
 #[derive(Clone)]
 pub struct Valve {
     rate: i64,
@@ -8,137 +9,98 @@ pub struct Valve {
 }
 type Valves = HashMap<u16, Valve>;
 
-const AA: u16 = ((b'A' as u16) << 8) | (b'A' as u16);
+pub struct Soln {}
+impl Soln {
+    const AA: u16 = ((b'A' as u16) << 8) | (b'A' as u16);
 
-#[inline]
-pub fn parse(input: &str) -> Valves {
-    input
-        .lines()
-        .map(|sline| {
-            let line = sline.as_bytes();
-            // If not for the different text when a valve only has a single tunnel,
-            // this wouldn't be necessary. But the different text does three things:
-            // 1) removes an s from tunnels (net -1)
-            // 2) adds an s to lead (net 0)
-            // 3) removes an s from valves (net -1)
-            // This means that the tunnel list can start at positions:
-            // 50 => 2 digit flow value, multiple tunnels. Char 48 is always an `s`
-            // 49 => 1 digit flow value, multiple tunnels. Char 48 is always a space
-            // 49 => 2 digit flow value, one tunnel. Char 48 is always a space
-            // 48 => 1 digit flow value, one tunnel. Char 48 is a capital A-Z.
-            let tunnels = match line[48] {
-                b's' => 50,
-                b' ' => 49,
-                _ => 48,
-            };
-            (
-                line[6..8].iter().fold(0, |a, b| (a << 8) | *b as u16),
-                Valve {
-                    rate: line[23..25].iter().fold(0, |a, b| match b {
-                        b';' => a,
-                        _ => (10 * a) + (b - b'0') as i64,
-                    }),
-                    connections: line[tunnels..]
-                        .split(|byte| b','.eq(byte) || b' '.eq(byte))
-                        .filter(|slc| slc.len() > 0)
-                        .map(|valve| valve.iter().fold(0, |a, b| (a << 8) | *b as u16))
-                        .collect(),
-                    open: false,
-                },
-            )
-        })
-        .collect()
-}
-
-pub fn double_valverun(
-    human: (u16, u16),
-    elephant: (u16, u16),
-    valves: &Valves,
-    time: i64,
-    highest: &mut HashMap<i64, i64>,
-    total: i64,
-    turnflow: i64,
-) -> i64 {
-    if time == 0 {
-        return total;
+    #[inline]
+    pub fn parse(input: &str) -> Valves {
+        input
+            .lines()
+            .map(|sline| {
+                let line = sline.as_bytes();
+                // If not for the different text when a valve only has a single tunnel,
+                // this wouldn't be necessary. But the different text does three things:
+                // 1) removes an s from tunnels (net -1)
+                // 2) adds an s to lead (net 0)
+                // 3) removes an s from valves (net -1)
+                // This means that the tunnel list can start at positions:
+                // 50 => 2 digit flow value, multiple tunnels. Char 48 is always an `s`
+                // 49 => 1 digit flow value, multiple tunnels. Char 48 is always a space
+                // 49 => 2 digit flow value, one tunnel. Char 48 is always a space
+                // 48 => 1 digit flow value, one tunnel. Char 48 is a capital A-Z.
+                let tunnels = match line[48] {
+                    b's' => 50,
+                    b' ' => 49,
+                    _ => 48,
+                };
+                (
+                    line[6..8].iter().fold(0, |a, b| (a << 8) | *b as u16),
+                    Valve {
+                        rate: line[23..25].iter().fold(0, |a, b| match b {
+                            b';' => a,
+                            _ => (10 * a) + (b - b'0') as i64,
+                        }),
+                        connections: line[tunnels..]
+                            .split(|byte| b','.eq(byte) || b' '.eq(byte))
+                            .filter(|slc| slc.len() > 0)
+                            .map(|valve| valve.iter().fold(0, |a, b| (a << 8) | *b as u16))
+                            .collect(),
+                        open: false,
+                    },
+                )
+            })
+            .collect()
     }
 
-    let best_time = match highest.get(&time) {
-        Some(&score) => score,
-        _ => 0,
-    };
-    // Same as p1. Works for the test input & my own input.
-    if best_time > (total + 26) {
-        return 0;
-    }
-    if total > best_time {
-        highest.insert(time, total);
-    }
-
-    let mut curmax = total;
-    let (hum_current, hum_last) = human;
-    let (ele_current, ele_last) = elephant;
-    let mut hum_valve = valves.get(&hum_current).unwrap().clone();
-    let mut ele_valve = valves.get(&ele_current).unwrap().clone();
-    let hum_conns = hum_valve.connections.clone();
-    let ele_conns = ele_valve.connections.clone();
-
-    // Both closed and positive flow available? Run both!
-    if !hum_valve.open
-        && hum_valve.rate > 0
-        && !ele_valve.open
-        && ele_valve.rate > 0
-        && hum_current != ele_current
-    {
-        hum_valve.open = true;
-        ele_valve.open = true;
-        let rate = ele_valve.rate + hum_valve.rate;
-        let mut cloned = valves.clone();
-        cloned.insert(ele_current, ele_valve);
-        cloned.insert(hum_current, hum_valve);
-        curmax = curmax.max(double_valverun(
-            (hum_current, 0),
-            (ele_current, 0),
-            &cloned,
-            time - 1,
-            highest,
-            total + turnflow,
-            turnflow + rate,
-        ));
-    }
-    // Human closed and positive flow available? Run it!
-    else if !hum_valve.open && hum_valve.rate > 0 {
-        hum_valve.open = true;
-        let rate = hum_valve.rate;
-        let mut cloned = valves.clone();
-        cloned.insert(hum_current, hum_valve);
-        for &label in &ele_conns {
-            if label == ele_last {
-                continue;
-            }
-            curmax = curmax.max(double_valverun(
-                (hum_current, 0),
-                (label, ele_current),
-                &cloned,
-                time - 1,
-                highest,
-                total + turnflow,
-                turnflow + rate,
-            ));
+    pub fn double_valverun(
+        human: (u16, u16),
+        elephant: (u16, u16),
+        valves: &Valves,
+        time: i64,
+        highest: &mut HashMap<i64, i64>,
+        total: i64,
+        turnflow: i64,
+    ) -> i64 {
+        if time == 0 {
+            return total;
         }
-    }
-    // Elephant closed and flow available? GOGOGOGOGO!
-    else if !ele_valve.open && ele_valve.rate > 0 {
-        ele_valve.open = true;
-        let rate = ele_valve.rate;
-        let mut cloned = valves.clone();
-        cloned.insert(ele_current, ele_valve);
-        for &label in &hum_conns {
-            if label == hum_last {
-                continue;
-            }
-            curmax = curmax.max(double_valverun(
-                (label, hum_current),
+
+        let best_time = match highest.get(&time) {
+            Some(&score) => score,
+            _ => 0,
+        };
+        // Same as p1. Works for the test input & my own input.
+        if best_time > (total + 26) {
+            return 0;
+        }
+        if total > best_time {
+            highest.insert(time, total);
+        }
+
+        let mut curmax = total;
+        let (hum_current, hum_last) = human;
+        let (ele_current, ele_last) = elephant;
+        let mut hum_valve = valves.get(&hum_current).unwrap().clone();
+        let mut ele_valve = valves.get(&ele_current).unwrap().clone();
+        let hum_conns = hum_valve.connections.clone();
+        let ele_conns = ele_valve.connections.clone();
+
+        // Both closed and positive flow available? Run both!
+        if !hum_valve.open
+            && hum_valve.rate > 0
+            && !ele_valve.open
+            && ele_valve.rate > 0
+            && hum_current != ele_current
+        {
+            hum_valve.open = true;
+            ele_valve.open = true;
+            let rate = ele_valve.rate + hum_valve.rate;
+            let mut cloned = valves.clone();
+            cloned.insert(ele_current, ele_valve);
+            cloned.insert(hum_current, hum_valve);
+            curmax = curmax.max(Self::double_valverun(
+                (hum_current, 0),
                 (ele_current, 0),
                 &cloned,
                 time - 1,
@@ -147,37 +109,95 @@ pub fn double_valverun(
                 turnflow + rate,
             ));
         }
-    }
-    // Neither has more flow available, time to walk all next paths instead
-    else {
-        for hum_label in hum_conns {
-            if hum_label == hum_last {
-                continue;
-            }
-            for &ele_label in &ele_conns {
-                if ele_label == ele_last {
+        // Human closed and positive flow available? Run it!
+        else if !hum_valve.open && hum_valve.rate > 0 {
+            hum_valve.open = true;
+            let rate = hum_valve.rate;
+            let mut cloned = valves.clone();
+            cloned.insert(hum_current, hum_valve);
+            for &label in &ele_conns {
+                if label == ele_last {
                     continue;
                 }
-                curmax = curmax.max(double_valverun(
-                    (hum_label, hum_current),
-                    (ele_label, ele_current),
-                    valves,
+                curmax = curmax.max(Self::double_valverun(
+                    (hum_current, 0),
+                    (label, ele_current),
+                    &cloned,
                     time - 1,
                     highest,
                     total + turnflow,
-                    turnflow,
+                    turnflow + rate,
                 ));
             }
         }
+        // Elephant closed and flow available? GOGOGOGOGO!
+        else if !ele_valve.open && ele_valve.rate > 0 {
+            ele_valve.open = true;
+            let rate = ele_valve.rate;
+            let mut cloned = valves.clone();
+            cloned.insert(ele_current, ele_valve);
+            for &label in &hum_conns {
+                if label == hum_last {
+                    continue;
+                }
+                curmax = curmax.max(Self::double_valverun(
+                    (label, hum_current),
+                    (ele_current, 0),
+                    &cloned,
+                    time - 1,
+                    highest,
+                    total + turnflow,
+                    turnflow + rate,
+                ));
+            }
+        }
+        // Neither has more flow available, time to walk all next paths instead
+        else {
+            for hum_label in hum_conns {
+                if hum_label == hum_last {
+                    continue;
+                }
+                for &ele_label in &ele_conns {
+                    if ele_label == ele_last {
+                        continue;
+                    }
+                    curmax = curmax.max(Self::double_valverun(
+                        (hum_label, hum_current),
+                        (ele_label, ele_current),
+                        valves,
+                        time - 1,
+                        highest,
+                        total + turnflow,
+                        turnflow,
+                    ));
+                }
+            }
+        }
+        curmax
     }
-    curmax
+
+    #[inline]
+    pub fn part_one(parsed: &Valves) -> i64 {
+        Self::double_valverun(
+            (Self::AA, 0),
+            (Self::AA, 0),
+            parsed,
+            26,
+            &mut HashMap::new(),
+            0,
+            0,
+        )
+    }
 }
 
-#[inline]
-pub fn part_one(parsed: &Valves) -> i64 {
-    double_valverun((AA, 0), (AA, 0), parsed, 26, &mut HashMap::new(), 0, 0)
-}
+impl crate::aocsoln::AOCSolution for Soln {
+    fn aoc_part1(raw_input: &[u8]) -> String {
+        let input = std::str::from_utf8(raw_input).unwrap();
+        Self::part_one(&Self::parse(input)).to_string()
+    }
 
-pub fn run(input: &str) -> i64 {
-    part_one(&parse(input))
+    fn aoc_part2(raw_input: &[u8]) -> String {
+        let input = std::str::from_utf8(raw_input).unwrap();
+        unimplemented!()
+    }
 }

--- a/runner/src/code.rs
+++ b/runner/src/code.rs
@@ -1,4 +1,6 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
+
+use ascii::{AsAsciiStr, AsciiStr};
 
 // structs and types cannot be part of struct impls
 #[derive(Clone)]
@@ -188,16 +190,17 @@ impl Soln {
             0,
         )
     }
-}
 
-impl crate::aocsoln::AOCSolution for Soln {
-    fn aoc_part1(raw_input: &[u8]) -> String {
-        let input = std::str::from_utf8(raw_input).unwrap();
-        Self::part_one(&Self::parse(input)).to_string()
+    //These are some of the possible signatures user submitted code could have.
+    pub fn run(input: &str) -> impl Display {
+        Self::part_one(&Self::parse(input))
     }
-
-    fn aoc_part2(raw_input: &[u8]) -> String {
-        let input = std::str::from_utf8(raw_input).unwrap();
-        unimplemented!()
+    pub fn run_ascii(input: &AsciiStr) -> impl Display {
+        let input_str = input.as_str();
+        Self::run(input_str)
+    }
+    pub fn run_bytes(input: &[u8]) -> impl Display {
+        let input_str = input.as_ascii_str().unwrap();
+        Self::run_ascii(input_str)
     }
 }

--- a/runner/src/code.rs
+++ b/runner/src/code.rs
@@ -181,15 +181,17 @@ pub fn part_one(parsed: &Valves) -> i64 {
     double_valverun((AA, 0), (AA, 0), parsed, 26, &mut HashMap::new(), 0, 0)
 }
 
-//These are some of the possible signatures user submitted code could have.
-//In practice there will be a single `run` function
 pub fn run(input: &str) -> impl Display {
     part_one(&parse(input))
 }
+//These are some of the other possible signatures that the user submitted `run`
+//function could have. In practice there will be a single `run` function
+#[allow(dead_code)]
 pub fn run_ascii(input: &AsciiStr) -> impl Display {
     let input_str = input.as_str();
     run(input_str)
 }
+#[allow(dead_code)]
 pub fn run_bytes(input: &[u8]) -> impl Display {
     let input_str = input.as_ascii_str().unwrap();
     run_ascii(input_str)

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod aocsoln;
+pub mod code;

--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -1,2 +1,1 @@
-pub mod aocsoln;
 pub mod code;

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,9 +1,7 @@
-#![feature(bench_black_box)]
-use std::{
-    hint::black_box,
-    time::{Duration, Instant},
-};
+mod aocsoln;
+mod code;
 
+use crate::aocsoln::AOCSolution;
 trait IntoInput<T: Copy> {
     fn into_input(self) -> T;
 }
@@ -27,60 +25,10 @@ impl IntoInput<&str> for Vec<u8> {
 }
 
 fn main() {
-    let input = std::env::var("INPUT").expect("No input file provided");
-    // let input = input.split(',').map(|s| s.parse().unwrap()).collect::<Vec<u8>>();
-    // let input = std::fs::read("input.txt").unwrap();
-    let (ans, mut times) = benchmark(input.into_bytes());
-
-    times.sort();
-    
-    println!("FERRIS_ELF_ANSWER {}", ans);
-    println!("FERRIS_ELF_MEDIAN {}", times[50].as_nanos());
-    println!("FERRIS_ELF_AVERAGE {}", times.iter().sum::<Duration>().as_nanos() / 100);
-    println!("FERRIS_ELF_MIN {}", times.iter().min().unwrap_or(&Duration::ZERO).as_nanos());
-    println!("FERRIS_ELF_MAX {}", times.iter().max().unwrap_or(&Duration::ZERO).as_nanos());
-}
-
-fn benchmark(input: Vec<u8>) -> (String, [Duration; 100]) {
-    let input = input.into_input();
-
-    let mut warmup_iters = 1;
-
-    let answer = format!("{}", ferris_elf::run(input));
-
-    println!("Answer: {}, warming up for 5 sec...", answer);
-
-    // Warm up the CPU etc for 5 seconds
-    let warmup_start = Instant::now();
-    while warmup_start.elapsed() < Duration::from_secs(5) {
-        if format!("{}", black_box(ferris_elf::run(black_box(input)))) != answer {
-            panic!("Solution returned two different answers on same input!")
-        }
-        warmup_iters += 1;
-    }
-
-    let estimated_dur = Duration::from_secs(5) / warmup_iters;
-    println!("Estimated duration per run: {:?}. Running {} iterations...", estimated_dur, warmup_iters);
-
-    let iters = (warmup_iters / 100).max(1);
-
-    // Times for eacha batch
-    let mut times = [Duration::ZERO; 100];
-
-    // Benchmark in 100 batches
-    let mut start = Instant::now();
-    for sample in 0..100 {
-        for _ in 0..iters {
-            let _ = black_box(ferris_elf::run(black_box(input)));
-        }
-
-        // Record this batch
-        let elapsed = start.elapsed();
-        times[sample] = elapsed / iters;
-        start += elapsed;
-    }
-
-    println!("Benchmark complete: {:#?}", times);
-
-    (answer, times)
+    //TODO: test that the answer is correct
+    let input = std::fs::read("inputs/input1.txt").unwrap();
+    let part1 = format!("{}", code::Soln::aoc_part1(&input));
+    println!("Part 1 = {part1}");
+    let part2 = format!("{}", code::Soln::aoc_part2(&input));
+    println!("Part 2 = {part2}");
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -26,10 +26,6 @@ fn main() {
     //TODO: test that the answer is correct
     let input = std::fs::read("inputs/input1.txt").unwrap();
     let input_ascii: &AsciiStr = input.as_ascii_str().unwrap();
-    let ans1 = code::run(input_ascii.as_ref()).to_string();
-    let ans2 = code::run_ascii(input_ascii.as_ref()).to_string();
-    let ans3 = code::run_bytes(input_ascii.as_bytes()).to_string();
-    assert!(ans1 == ans2 && ans2 == ans3);
-
-    println!("Answers = {ans1} = {ans2} = {ans3}");
+    let answer = code::run(input_ascii.as_ref()).to_string();
+    println!("{}", answer);
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,7 +1,5 @@
-mod aocsoln;
+use ascii::{AsAsciiStr, AsciiStr, IntoAsciiString};
 mod code;
-
-use crate::aocsoln::AOCSolution;
 trait IntoInput<T: Copy> {
     fn into_input(self) -> T;
 }
@@ -27,8 +25,11 @@ impl IntoInput<&str> for Vec<u8> {
 fn main() {
     //TODO: test that the answer is correct
     let input = std::fs::read("inputs/input1.txt").unwrap();
-    let part1 = format!("{}", code::Soln::aoc_part1(&input));
-    println!("Part 1 = {part1}");
-    let part2 = format!("{}", code::Soln::aoc_part2(&input));
-    println!("Part 2 = {part2}");
+    let input_ascii: &AsciiStr = input.as_ascii_str().unwrap();
+    let ans1 = code::Soln::run(input_ascii.as_ref());
+    let ans2 = code::Soln::run_ascii(input_ascii.as_ref());
+    let ans3 = code::Soln::run_bytes(input_ascii.as_bytes());
+
+    // let answer = format!("{}", code::Soln::run(&input));
+    println!("Answers = {ans1} = {ans2} = {ans3}");
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,4 +1,4 @@
-use ascii::{AsAsciiStr, AsciiStr, IntoAsciiString};
+use ascii::{AsAsciiStr, AsciiStr};
 mod code;
 trait IntoInput<T: Copy> {
     fn into_input(self) -> T;
@@ -26,10 +26,10 @@ fn main() {
     //TODO: test that the answer is correct
     let input = std::fs::read("inputs/input1.txt").unwrap();
     let input_ascii: &AsciiStr = input.as_ascii_str().unwrap();
-    let ans1 = code::Soln::run(input_ascii.as_ref());
-    let ans2 = code::Soln::run_ascii(input_ascii.as_ref());
-    let ans3 = code::Soln::run_bytes(input_ascii.as_bytes());
+    let ans1 = code::run(input_ascii.as_ref()).to_string();
+    let ans2 = code::run_ascii(input_ascii.as_ref()).to_string();
+    let ans3 = code::run_bytes(input_ascii.as_bytes()).to_string();
+    assert!(ans1 == ans2 && ans2 == ans3);
 
-    // let answer = format!("{}", code::Soln::run(&input));
     println!("Answers = {ans1} = {ans2} = {ans3}");
 }


### PR DESCRIPTION
This change replaces the hand-rolled benchmarks with `criterion`. Few things of note:

- criterion has its own benchmark harness which generates a main function and runs the code so the benchmarks have to be launched externally - see the shell script
- there is no easy way to get the benchmark results programatically because of the harness and macros, so we output them to JSON instead. [docs](https://bheisler.github.io/criterion.rs/book/cargo_criterion/external_tools.html). this also means we have to use the cargo-criterion lib.
- there is also no way to enforce a hard time-limit on benchmarks via criterion, so the shell script does that
- i added a trait that solutions must implement so we can implement the benchmark code generically. to implement the trait i have to wrap the solution in a `struct` which means adding a few `Self::`s to function calls in the solution. the github diffs view is confusing but that's really the only actual change to the solution.

resolves #4 