### PR TITLE
fix: Remove broken timer dependency

### DIFF
--- a/ops/systemd/ferris-elf-fetch.timer
+++ b/ops/systemd/ferris-elf-fetch.timer
@@ -1,6 +1,5 @@
 [Unit]
 Description="Ferris Elf input fetch timer"
-Requires=network-online.target
 
 [Timer]
 OnCalendar=*-12-01..26 00:00:15 America/New_York

--- a/ops/systemd/ferris-elf-update.timer
+++ b/ops/systemd/ferris-elf-update.timer
@@ -1,6 +1,5 @@
 [Unit]
 Description="Ferris Elf update timer"
-Requires=network-online.target
 
 [Timer]
 OnCalendar=*:5/5


### PR DESCRIPTION
The targets that exist in system-level systemd don't all exist in user-level systemd. There's no correct target for these, so let's just run them whenever.