### PR TITLE
fix: Make the fetch script retrieve the current year's inputs

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -1,5 +1,7 @@
+from datetime import datetime, timezone, timedelta
 import requests
 import os, os.path, sys
+from zoneinfo import ZoneInfo
 
 from config import settings
 from lib import today
@@ -11,8 +13,9 @@ aoc_base_dir = settings.aoc.inputs_dir
 def get(day):
     print(f"Fetching {day}")
     day_dir = os.path.join(aoc_base_dir, str(day))
+    year = datetime.now(tz=ZoneInfo("America/New_York")).year
     for label, k in keys.items():
-        r = requests.get(f"https://adventofcode.com/2022/day/{day}/input", cookies=dict(session=k))
+        r = requests.get(f"https://adventofcode.com/{year}/day/{day}/input", cookies=dict(session=k))
         r.raise_for_status()
         if not os.path.exists(day_dir):
             os.makedirs(day_dir)

--- a/fetch.py
+++ b/fetch.py
@@ -15,7 +15,9 @@ def get(day):
     day_dir = os.path.join(aoc_base_dir, str(day))
     year = datetime.now(tz=ZoneInfo("America/New_York")).year
     for label, k in keys.items():
-        r = requests.get(f"https://adventofcode.com/{year}/day/{day}/input", cookies=dict(session=k))
+        r = requests.get(
+            f"https://adventofcode.com/{year}/day/{day}/input", cookies=dict(session=k)
+        )
         r.raise_for_status()
         if not os.path.exists(day_dir):
             os.makedirs(day_dir)

--- a/lib.py
+++ b/lib.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 import functools
 import traceback
 import os
+from zoneinfo import ZoneInfo
 
 import docker
 from database import Database
@@ -157,6 +158,5 @@ def get_best_times(day):
     return (times1, times2)
 
 def today():
-    utc = datetime.now(timezone.utc)
-    offset = timedelta(hours=-5)
-    return min((utc + offset).day, 25)
+    stamp = datetime.now(tz=ZoneInfo("America/New_York"))
+    return min(stamp.day, 25)

--- a/lib.py
+++ b/lib.py
@@ -157,6 +157,7 @@ def get_best_times(day):
         times2.append((user_id, time))
     return (times1, times2)
 
+
 def today():
     stamp = datetime.now(tz=ZoneInfo("America/New_York"))
     return min(stamp.day, 25)

--- a/lib.py
+++ b/lib.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timedelta, timezone
 import functools
 import traceback
 import os
@@ -154,3 +155,8 @@ def get_best_times(day):
         user_id = int(user_id)
         times2.append((user_id, time))
     return (times1, times2)
+
+def today():
+    utc = datetime.now(timezone.utc)
+    offset = timedelta(hours=-5)
+    return min((utc + offset).day, 25)


### PR DESCRIPTION
The fetch script was hard-coded to return inputs from 2022 previously. I fixed it so that it would instead always choose the current year.