### PR TITLE
feat: Add top 100 most-downloaded crates as additional runner dependencies

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,6 +27,5 @@ jobs:
         registry: ghcr.io
         default_branch: main
         workdir: runner
-        buildoptions: "--volume ./benches/:/app/benches --volume ./src/:/app/src/"
         tags: "latest,${{ steps.dategen.outputs.docker-version }}"
         no_push: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,5 +27,6 @@ jobs:
         registry: ghcr.io
         default_branch: main
         workdir: runner
+        buildoptions: "--volume ./benches/:/app/benches --volume ./src/:/app/src/"
         tags: "latest,${{ steps.dategen.outputs.docker-version }}"
         no_push: ${{ github.event_name == 'pull_request' }}

--- a/bot.py
+++ b/bot.py
@@ -32,7 +32,7 @@ class MyBot(commands.Bot):
         )
 
     async def on_ready(self):
-        print("Logged in as", self.user)
+        logger.info("Logged in as %s", self.user)
         while True:
             try:
                 submit_msg = await self.queue.get()
@@ -94,6 +94,7 @@ class Commands(commands.Cog):
                      code: discord.Attachment):
         if day > lib.today():
             raise commands.BadArgument(f"Day {day} is in the future!")
+        await ctx.reply("Submitting...")
         logger.info(
             "Queueing submission for %s, message = [%s], queue length = %s",
             ctx.author,
@@ -102,8 +103,8 @@ class Commands(commands.Cog):
         )
         # using a tuple is probably the most readable but shut
         self.bot.queue.put_nowait((ctx, day, part, await code.read()))
-        await ctx.reply(
-            f"Your submission for day {day} part {part} has been queued. "
+        await ctx.interaction.edit_original_response(
+            content=f"Your submission for day {day} part {part} has been queued. " +
             f"There are {self.bot.queue.qsize()} submissions in the queue."
         )
 
@@ -122,7 +123,8 @@ async def prefix(dbot: commands.Bot, message: discord.Message) -> list[str]:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(encoding="utf-8", level=logging.INFO)
+    logformat = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
+    logging.basicConfig(encoding="utf-8", level=logging.INFO, datefmt="%a, %d %b %Y %H:%M:%S %z", format=logformat)
 
     intents = discord.Intents.default()
     intents.message_content = True
@@ -150,4 +152,4 @@ if __name__ == "__main__":
         # disallows the bot from mentioning things it shouldn't, just in case
         allowed_mentions=discord.AllowedMentions(everyone=False, users=True, roles=False, replied_user=True)
     )
-    bot.run(settings.discord.bot_token)
+    bot.run(settings.discord.bot_token, log_handler=None)

--- a/lib.py
+++ b/lib.py
@@ -126,10 +126,10 @@ async def build_code(author_name: str, author_id: int, tmp_dir: str) -> bool:
             stdout=True,
             mem_limit="8g",
             network_mode="none",
+            # Don't mount the inputs directory here for defense-in-depth
             volumes={
                 os.path.join(tmp_dir, "src"): {'bind': '/app/src', 'mode': 'rw'},
                 os.path.join(tmp_dir, "benches"): {'bind': '/app/benches', 'mode': 'rw'},
-                os.path.join(tmp_dir, "inputs"): {'bind': '/app/inputs', 'mode': 'rw'},
                 os.path.join(tmp_dir, "target"): {'bind': '/app/target', 'mode': 'rw'},
                 }
         ))

--- a/lib.py
+++ b/lib.py
@@ -12,7 +12,7 @@ import traceback
 from dataclasses import dataclass
 from datetime import datetime
 from sqlite3 import Cursor
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 from zoneinfo import ZoneInfo
 
 import discord
@@ -48,7 +48,8 @@ async def benchmark(ctx: commands.Context, day: int, part: int, code: bytes, ):
                 load_input(tmpdir, day, in_file)
                 result_lst = await run_code(op_name, op_id, tmpdir, in_file)
                 result = process_run_result(in_file, answers_map, result_lst)
-                results.append(result)
+                if result is not None:
+                    results.append(result)
 
             if len(results) > 0:
                 save_results(cur, op_id, day, part, code, results)
@@ -95,13 +96,17 @@ def populate_tmp_dir(tmp_dir: str, solution_code: bytes):
     # Step 1: Copy all the rust files
     script_dir = os.path.dirname(__file__)
     runner_src_dir = os.path.join(script_dir, "runner")
-    ignores = shutil.ignore_patterns("*target*", "Dockerfile", "**/.gitkeep")
+    # The ignores were causing problems with building
+    # ignores = shutil.ignore_patterns("target/", "Dockerfile", "**/.gitkeep")
+    ignores = shutil.ignore_patterns()
     shutil.copytree(runner_src_dir, tmp_dir, dirs_exist_ok=True, ignore=ignores)
 
     # Step 2: Write code.
     code_path = os.path.join(tmp_dir, "src", "code.rs")
     with open(code_path, "wb") as code_file:
         code_file.write(solution_code)
+    
+    logger.debug("Contents of tmp dir: %s", os.listdir(tmp_dir))
 
 
 async def build_code(author_name: str, author_id: int, tmp_dir: str) -> bool:
@@ -120,8 +125,13 @@ async def build_code(author_name: str, author_id: int, tmp_dir: str) -> bool:
             remove=True,
             stdout=True,
             mem_limit="8g",
-            # network_mode="none", # Want no-network, but it's downloading crates. :(
-            volumes={tmp_dir: {'bind': '/app', 'mode': 'rw'}}
+            network_mode="none",
+            volumes={
+                os.path.join(tmp_dir, "src"): {'bind': '/app/src', 'mode': 'rw'},
+                os.path.join(tmp_dir, "benches"): {'bind': '/app/benches', 'mode': 'rw'},
+                os.path.join(tmp_dir, "inputs"): {'bind': '/app/inputs', 'mode': 'rw'},
+                os.path.join(tmp_dir, "target"): {'bind': '/app/target', 'mode': 'rw'},
+                }
         ))
         out = out.decode("utf-8")
         logger.debug("Build container output: %s", out)
@@ -191,7 +201,7 @@ async def run_code(author_name: str, author_id: int, tmp_dir: str, in_file: str)
         out = await loop.run_in_executor(None, functools.partial(
             doc.containers.run,
             settings.docker.container_ref,
-            "timeout --kill-after=5s 60s cargo criterion --message-format=json",
+            "timeout --kill-after=15s 120s cargo criterion --message-format=json",
             environment={
                 "FERRIS_ELF_INPUT_FILE_NAME": in_file_name,
             },
@@ -199,8 +209,13 @@ async def run_code(author_name: str, author_id: int, tmp_dir: str, in_file: str)
             stdout=True,
             stderr=True,
             mem_limit="8g",
-            # network_mode="none", # Downloading crates.
-            volumes={tmp_dir: {'bind': '/app', 'mode': 'rw'}}
+            network_mode="none",
+            volumes={
+                os.path.join(tmp_dir, "src"): {'bind': '/app/src', 'mode': 'rw'},
+                os.path.join(tmp_dir, "benches"): {'bind': '/app/benches', 'mode': 'rw'},
+                os.path.join(tmp_dir, "inputs"): {'bind': '/app/inputs', 'mode': 'rw'},
+                os.path.join(tmp_dir, "target"): {'bind': '/app/target', 'mode': 'rw'},
+                }
         ))
         out: str = out.decode("utf-8")
         logger.debug("Run container output (type: %s):\n%s", type(out), out)
@@ -232,11 +247,13 @@ class RunResult:
     low_bound: Optional[float]
 
 
-def process_run_result(in_file, answers_map, result_lst) -> RunResult:
+def process_run_result(in_file: str, answers_map: dict[str, Any], result_lst: Optional[list[dict[str, Any]]]) -> Optional[RunResult]:
     """Given JSON blobs extracted from a container's stdout, get the core stats out."""
-    # `result` should be a dataclass, not a dict. Another time.
-    result = RunResult(answer="", verified=False, typical=None, average=None, median=None, high_bound=None,
-                       low_bound=None)
+    result = RunResult(answer="", verified=False, typical=None, average=None, median=None, 
+                       high_bound=None, low_bound=None)
+    if result_lst is None:
+        logger.info("No run result due to lack of container output. Did the container error out?")
+        return None
     for blob in result_lst:
         reason = blob.get("reason", None)
         if reason is None:

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -151,6 +151,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "async-recursion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,12 +256,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -630,6 +668,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +850,7 @@ dependencies = [
  "ahash",
  "aho-corasick",
  "allocator-api2",
+ "anes",
  "ansi_term",
  "anstream",
  "anstyle",
@@ -807,6 +859,9 @@ dependencies = [
  "anyhow",
  "approx",
  "arc-swap",
+ "arrayvec",
+ "ascii",
+ "async-recursion",
  "async-trait",
  "atomic",
  "atty",
@@ -818,15 +873,21 @@ dependencies = [
  "bit_field",
  "bitflags 1.3.2",
  "bitflags 2.4.1",
+ "bitvec",
  "block-buffer",
+ "btoi",
  "bytemuck",
  "bytemuck_derive",
  "byteorder",
  "bytes 0.4.12",
  "bytes 1.5.0",
+ "cast",
  "cc",
  "cfg-if",
  "chrono",
+ "ciborium",
+ "ciborium-io",
+ "ciborium-ll",
  "clap",
  "clap_builder",
  "clap_derive",
@@ -836,9 +897,11 @@ dependencies = [
  "const-default",
  "cookie",
  "cookie_store",
+ "cpp_demangle",
  "cpufeatures",
  "crc32fast",
  "criterion",
+ "criterion-plot",
  "crossbeam",
  "crossbeam-channel",
  "crossbeam-deque",
@@ -848,7 +911,9 @@ dependencies = [
  "crypto-common",
  "csv",
  "csv-core",
+ "dashmap",
  "data-encoding",
+ "debugid",
  "deranged",
  "derivative",
  "destructure_traitobject",
@@ -867,6 +932,7 @@ dependencies = [
  "fastrand",
  "fdeflate",
  "filetime",
+ "findshlibs",
  "finl_unicode",
  "fixedbitset",
  "flate2",
@@ -875,6 +941,7 @@ dependencies = [
  "foreign-types",
  "foreign-types-shared",
  "form_urlencoded",
+ "funty",
  "futf",
  "futures 0.1.31",
  "futures 0.3.29",
@@ -894,6 +961,7 @@ dependencies = [
  "glob",
  "h2 0.3.22",
  "h2 0.4.0",
+ "half 1.8.2",
  "half 2.2.1",
  "hashbrown 0.12.3",
  "hashbrown 0.14.3",
@@ -921,6 +989,7 @@ dependencies = [
  "iovec",
  "ipnet",
  "is-terminal",
+ "itertools 0.10.5",
  "itertools 0.12.0",
  "itoa",
  "jpeg-decoder",
@@ -943,6 +1012,7 @@ dependencies = [
  "md-5",
  "memchr",
  "memmap",
+ "memmap2",
  "memoffset",
  "mime",
  "mime_guess",
@@ -954,6 +1024,7 @@ dependencies = [
  "native-tls",
  "ndarray",
  "new_debug_unreachable",
+ "nix",
  "nom",
  "num",
  "num-bigint",
@@ -965,6 +1036,7 @@ dependencies = [
  "num_cpus",
  "object",
  "once_cell",
+ "oorandom",
  "openssl",
  "openssl-macros",
  "openssl-probe",
@@ -972,6 +1044,7 @@ dependencies = [
  "ordered-float",
  "parking_lot",
  "parking_lot_core",
+ "parse",
  "paste",
  "percent-encoding",
  "petgraph",
@@ -986,6 +1059,9 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "pkg-config",
+ "plotters",
+ "plotters-backend",
+ "plotters-svg",
  "png",
  "postgres",
  "postgres-protocol",
@@ -999,6 +1075,7 @@ dependencies = [
  "publicsuffix",
  "qoi",
  "quote",
+ "radium",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -1039,13 +1116,17 @@ dependencies = [
  "smawk",
  "socket2",
  "spin",
+ "stable_deref_trait",
  "string_cache",
  "string_cache_codegen",
  "stringprep",
  "strsim",
  "subtle",
+ "symbolic-common",
+ "symbolic-demangle",
  "syn 1.0.109",
  "syn 2.0.42",
+ "tap",
  "tar",
  "tempfile",
  "tendril",
@@ -1061,6 +1142,7 @@ dependencies = [
  "time",
  "time-core",
  "time-macros",
+ "tinytemplate",
  "tinyvec",
  "tinyvec_macros",
  "tokio",
@@ -1101,6 +1183,7 @@ dependencies = [
  "whoami",
  "wide",
  "winnow",
+ "wyz",
  "xattr",
  "xml5ever",
  "yaml-rust",
@@ -1194,6 +1277,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -2292,6 +2381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47351ddb9a500ad0b31aa5731980f2678886e44e96a5e3e0d837c5062a151239"
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +2681,12 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3175,6 +3276,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -3980,6 +4087,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -40,10 +40,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
 
 [[package]]
 name = "anstyle"
@@ -52,16 +96,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
+name = "async-trait"
+version = "0.1.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -85,6 +200,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit_field"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,24 +239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
+name = "block-buffer"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "btoi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
-dependencies = [
- "num-traits",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -128,6 +258,42 @@ name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
+
+[[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cast"
@@ -149,6 +315,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "ciborium"
@@ -174,7 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 1.8.2",
 ]
 
 [[package]]
@@ -184,6 +365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -192,8 +374,25 @@ version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+ "terminal_size",
+ "unicase",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -203,10 +402,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "const-default"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
+dependencies = [
+ "cookie",
+ "idna 0.2.3",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
@@ -223,7 +502,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -244,14 +523,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c3242926edf34aec4ac3a77108ad4854bffaa2e4ddc1824124ce59231302d5"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -260,38 +563,77 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9bcf5bdbfdd6030fb4a1c497b5d5fc5921aa2f60d359a17e249c0e6df3de153"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
+name = "crunchy"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "cfg-if",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
+ "generic-array 0.14.7",
+ "typenum",
 ]
+
+[[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "debugid"
@@ -303,10 +645,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "destructure_traitobject"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "equivalent"
@@ -325,31 +726,400 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "backtrace",
+ "version_check",
+]
+
+[[package]]
+name = "exr"
+version = "1.71.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832a761f35ab3e6664babfbdc6cef35a4860e816ec3916dcfd0882954e98a8a8"
+dependencies = [
+ "bit_field",
+ "flume",
+ "half 2.2.1",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "faster-hex"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239f7bfb930f820ab16a9cd95afc26f88264cf6905c960b340a615384aa3338a"
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d6dafc854908ff5da46ff3f8f473c6984119a2876a383a860246dd7841a868"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "ferris-elf"
 version = "0.0.0"
 dependencies = [
- "arrayvec",
- "ascii",
- "bitvec",
- "btoi",
+ "addr2line",
+ "adler",
+ "ahash",
+ "aho-corasick",
+ "allocator-api2",
+ "ansi_term",
+ "anstream",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anyhow",
+ "approx",
+ "arc-swap",
+ "async-trait",
+ "atomic",
+ "atty",
+ "autocfg",
+ "backtrace",
+ "base64",
+ "bit-set",
+ "bit-vec",
+ "bit_field",
+ "bitflags 1.3.2",
+ "bitflags 2.4.1",
+ "block-buffer",
  "bytemuck",
+ "bytemuck_derive",
+ "byteorder",
+ "bytes 0.4.12",
+ "bytes 1.5.0",
+ "cc",
+ "cfg-if",
+ "chrono",
+ "clap",
+ "clap_builder",
+ "clap_derive",
+ "clap_lex",
+ "color_quant",
+ "colorchoice",
+ "const-default",
+ "cookie",
+ "cookie_store",
+ "cpufeatures",
+ "crc32fast",
  "criterion",
- "dashmap",
- "itertools",
+ "crossbeam",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "crypto-common",
+ "csv",
+ "csv-core",
+ "data-encoding",
+ "deranged",
+ "derivative",
+ "destructure_traitobject",
+ "digest",
+ "either",
+ "encoding_rs",
+ "env_logger",
+ "equivalent",
+ "errno",
+ "error-chain",
+ "exr",
+ "fallible-iterator 0.2.0",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "faster-hex",
+ "fastrand",
+ "fdeflate",
+ "filetime",
+ "finl_unicode",
+ "fixedbitset",
+ "flate2",
+ "flume",
+ "fnv",
+ "foreign-types",
+ "foreign-types-shared",
+ "form_urlencoded",
+ "futf",
+ "futures 0.1.31",
+ "futures 0.3.29",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "generic-array 0.14.7",
+ "generic-array 1.0.0",
+ "getrandom",
+ "gif",
+ "gimli",
+ "glob",
+ "h2 0.3.22",
+ "h2 0.4.0",
+ "half 2.2.1",
+ "hashbrown 0.12.3",
+ "hashbrown 0.14.3",
+ "hashlink",
+ "heck",
+ "hmac",
+ "html5ever",
+ "http 0.2.11",
+ "http 1.0.0",
+ "http-body 0.4.6",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "humantime",
+ "hyper 0.14.28",
+ "hyper 1.1.0",
+ "hyper-tls",
+ "iana-time-zone",
+ "idna 0.2.3",
+ "idna 0.3.0",
+ "idna 0.5.0",
+ "image",
+ "indexmap 1.9.3",
+ "indexmap 2.1.0",
+ "iovec",
+ "ipnet",
+ "is-terminal",
+ "itertools 0.12.0",
+ "itoa",
+ "jpeg-decoder",
+ "lazy_static",
+ "lebe",
+ "libc",
+ "libm",
+ "libsqlite3-sys",
+ "linked-hash-map",
+ "linux-raw-sys",
+ "lock_api",
+ "log",
+ "log-mdc",
+ "log4rs",
+ "mac",
+ "markup5ever",
+ "markup5ever_rcdom",
+ "matches",
+ "matrixmultiply",
+ "md-5",
  "memchr",
+ "memmap",
+ "memoffset",
+ "mime",
+ "mime_guess",
+ "minimal-lexical",
+ "miniz_oxide",
+ "mio",
+ "nalgebra",
+ "nalgebra-macros",
+ "native-tls",
+ "ndarray",
+ "new_debug_unreachable",
  "nom",
- "parse-display",
+ "num",
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+ "num_cpus",
+ "object",
+ "once_cell",
+ "openssl",
+ "openssl-macros",
+ "openssl-probe",
+ "openssl-sys",
+ "ordered-float",
+ "parking_lot",
+ "parking_lot_core",
+ "paste",
+ "percent-encoding",
+ "petgraph",
+ "phf 0.10.1",
+ "phf 0.11.2",
+ "phf_codegen",
+ "phf_generator 0.10.0",
+ "phf_generator 0.11.2",
+ "phf_macros",
+ "phf_shared 0.10.0",
+ "phf_shared 0.11.2",
+ "pin-project-lite",
+ "pin-utils",
+ "pkg-config",
+ "png",
+ "postgres",
+ "postgres-protocol",
+ "postgres-types",
+ "powerfmt",
  "pprof",
+ "ppv-lite86",
+ "precomputed-hash",
+ "proc-macro2",
+ "psl-types",
+ "publicsuffix",
+ "qoi",
+ "quote",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "rand_distr",
+ "rawpointer",
  "rayon",
+ "rayon-core",
  "regex",
- "rustc-hash",
+ "regex-automata",
+ "regex-syntax",
+ "reqwest",
+ "ring",
+ "rusqlite",
+ "rustc-demangle",
+ "rustc_version",
+ "rustix",
+ "ryu",
+ "safe_arch",
+ "same-file",
+ "scopeguard",
+ "select",
+ "semver",
+ "serde",
+ "serde-value",
+ "serde_derive",
+ "serde_json",
+ "serde_spanned",
+ "serde_urlencoded",
+ "serde_yaml",
+ "sha1_smol",
+ "sha2",
+ "signal-hook-registry",
+ "simba",
+ "simd-adler32",
+ "siphasher",
+ "slab",
  "smallvec",
+ "smawk",
+ "socket2",
+ "spin",
+ "string_cache",
+ "string_cache_codegen",
+ "stringprep",
+ "strsim",
+ "subtle",
+ "syn 1.0.109",
+ "syn 2.0.42",
+ "tar",
+ "tempfile",
+ "tendril",
+ "termcolor",
+ "terminal_size",
+ "textwrap",
+ "thiserror",
+ "thiserror-impl",
+ "thread-id",
+ "thread_local",
+ "threadpool",
+ "tiff",
+ "time",
+ "time-core",
+ "time-macros",
+ "tinyvec",
+ "tinyvec_macros",
+ "tokio",
+ "tokio-io",
+ "tokio-macros",
+ "tokio-native-tls",
+ "tokio-postgres",
+ "tokio-util",
+ "toml",
+ "toml_datetime",
+ "toml_edit",
+ "tower-service",
+ "tracing",
+ "tracing-attributes",
+ "tracing-core",
+ "try-lock",
+ "typemap-ors",
+ "typenum",
+ "unicase",
+ "unicode-bidi",
+ "unicode-ident",
+ "unicode-linebreak",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "unicode-width",
+ "unicode-xid",
+ "unsafe-any-ors",
+ "untrusted",
+ "url",
+ "utf-8",
+ "utf8parse",
+ "uuid",
+ "vcpkg",
+ "version_check",
+ "walkdir",
+ "want",
+ "weezl",
+ "whoami",
+ "wide",
+ "winnow",
+ "xattr",
+ "xml5ever",
+ "yaml-rust",
+ "zerocopy",
+ "zerocopy-derive",
+ "zeroize",
+ "zune-inflate",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -365,10 +1135,196 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
+name = "finl_unicode"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
+name = "futures"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
+
+[[package]]
+name = "futures"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+ "num_cpus",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+
+[[package]]
+name = "futures-task"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+
+[[package]]
+name = "futures-util"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+dependencies = [
+ "futures 0.1.31",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "tokio-io",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
+dependencies = [
+ "const-default",
+ "faster-hex",
+ "serde",
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "getrandom"
@@ -382,10 +1338,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "h2"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+dependencies = [
+ "bytes 1.5.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.11",
+ "indexmap 2.1.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+dependencies = [
+ "bytes 1.5.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
+ "indexmap 2.1.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "half"
@@ -394,10 +1404,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "half"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -406,13 +1459,237 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+dependencies = [
+ "bytes 1.5.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes 1.5.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes 1.5.0",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes 1.5.0",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes 1.5.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.22",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes 1.5.0",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.0",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.5.0",
+ "hyper 0.14.28",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "image"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "exr",
+ "gif",
+ "jpeg-decoder",
+ "num-rational",
+ "num-traits",
+ "png",
+ "qoi",
+ "tiff",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -422,7 +1699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
  "ahash",
- "indexmap",
+ "indexmap 2.1.0",
  "is-terminal",
  "itoa",
  "log",
@@ -434,12 +1711,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -454,10 +1746,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.9"
+name = "itertools"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "js-sys"
@@ -475,10 +1785,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.150"
+name = "lebe"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+
+[[package]]
+name = "libc"
+version = "0.2.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -501,6 +1840,99 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
+
+[[package]]
+name = "log4rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "chrono",
+ "derivative",
+ "fnv",
+ "humantime",
+ "libc",
+ "log",
+ "log-mdc",
+ "parking_lot",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "thread-id",
+ "typemap-ors",
+ "winapi",
+]
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf 0.10.1",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -509,10 +1941,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "memmap2"
-version = "0.9.0"
+name = "memmap"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
 dependencies = [
  "libc",
 ]
@@ -524,6 +1966,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -539,7 +1997,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
+
+[[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
@@ -563,6 +2098,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,12 +2142,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "libc",
 ]
 
 [[package]]
@@ -592,15 +2205,68 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "openssl"
+version = "0.10.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"
@@ -626,30 +2292,124 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-display"
-version = "0.6.0"
+name = "paste"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b25af4ef94a8528b41fb49a696e361dc6ef975c782417268072d987ac327964"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
- "once_cell",
- "parse-display-derive",
- "regex",
+ "fixedbitset",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
-name = "parse-display-derive"
-version = "0.6.0"
+name = "phf"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f106cced1f4b645e3fca6125105cdf7407e35d1af710f290aac530f6b826b9"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "once_cell",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared 0.11.2",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "regex",
- "regex-syntax 0.6.29",
- "structmeta",
- "syn 1.0.109",
+ "syn 2.0.42",
 ]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "plotters"
@@ -680,6 +2440,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.17.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "postgres"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7915b33ed60abc46040cbcaa25ffa1c7ec240668e0477c4f3070786f5916d451"
+dependencies = [
+ "bytes 1.5.0",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes 1.5.0",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
+dependencies = [
+ "bytes 1.5.0",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "pprof"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,12 +2524,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.70"
+name = "ppv-lite86"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -729,10 +2588,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "serde",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+ "serde",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -772,7 +2673,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -783,20 +2684,55 @@ checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "reqwest"
+version = "0.11.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+dependencies = [
+ "base64",
+ "bytes 1.5.0",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.22",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "rgb"
@@ -808,22 +2744,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
+dependencies = [
+ "bitflags 2.4.1",
+ "chrono",
+ "csv",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "serde_json",
+ "smallvec",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
+name = "rustc_version"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -834,9 +2807,18 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -848,10 +2830,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "select"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9da09dc3f4dfdb6374cbffff7a2cffcec316874d4429899eefdc97b3b94dcd"
+dependencies = [
+ "bit-set",
+ "html5ever",
+ "markup5ever_rcdom",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
@@ -863,6 +2894,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,7 +2911,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -885,10 +2926,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap 1.9.3",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -903,27 +3062,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
-name = "structmeta"
-version = "0.1.6"
+name = "string_cache"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104842d6278bf64aa9d2f182ba4bde31e8aec7a131d29b7f444bb9b344a09e2a"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive",
- "syn 1.0.109",
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared 0.10.0",
+ "precomputed-hash",
+ "serde",
 ]
 
 [[package]]
-name = "structmeta-derive"
-version = "0.1.6"
+name = "string_cache_codegen"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24420be405b590e2d746d83b01f09af673270cf80e9b003a5fa7b651c58c7d93"
+checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
 dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
 ]
+
+[[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "symbolic-common"
@@ -961,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -971,10 +3156,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
+name = "system-configuration"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"
@@ -990,23 +3201,133 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.50"
+name = "tendril"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "thread-id"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "tiff"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
+]
+
+[[package]]
+name = "time"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -1020,16 +3341,322 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "serde",
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+dependencies = [
+ "backtrace",
+ "bytes 1.5.0",
+ "libc",
+ "mio",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "log",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes 1.5.0",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf 0.11.2",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes 1.5.0",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typemap-ors"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
+dependencies = [
+ "unsafe-any-ors",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unsafe-any-ors"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
+dependencies = [
+ "destructure_traitobject",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna 0.5.0",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+dependencies = [
+ "atomic",
+ "getrandom",
+ "md-5",
+ "serde",
+ "sha1_smol",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1045,6 +3672,15 @@ checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1074,8 +3710,20 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.42",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1096,7 +3744,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.42",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1115,6 +3763,32 @@ checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -1147,6 +3821,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1281,30 +3964,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
+name = "winnow"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
- "tap",
+ "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "xattr"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7dae5072fe1f8db8f8d29059189ac175196e410e40ba42d5d4684ae2f750995"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034e1d05af98b51ad7214527730626f019682d797ba38b51689212118d8e650"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
 ]

--- a/runner/Cargo.lock
+++ b/runner/Cargo.lock
@@ -1182,6 +1182,8 @@ dependencies = [
  "weezl",
  "whoami",
  "wide",
+ "windows-targets 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
  "winnow",
  "wyz",
  "xattr",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -11,6 +11,11 @@ pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
 name = "bench"
 harness = false
 
+[dependencies.addr2line]
+package = "addr2line"
+version = "=0.21.0"
+default-features = false
+
 [dependencies.adler]
 package = "adler"
 version = "=1.0.2"
@@ -31,6 +36,10 @@ package = "allocator-api2"
 version = "=0.2.16"
 features = ["alloc"]
 default-features = false
+
+[dependencies.anes]
+package = "anes"
+version = "=0.1.6"
 
 [dependencies.ansi_term]
 package = "ansi_term"
@@ -68,6 +77,20 @@ features = ["std"]
 [dependencies.arc_swap]
 package = "arc-swap"
 version = "=1.6.0"
+
+[dependencies.arrayvec]
+package = "arrayvec"
+version = "=0.7.4"
+features = ["std"]
+
+[dependencies.ascii]
+package = "ascii"
+version = "=1.1.0"
+features = ["alloc", "std"]
+
+[dependencies.async_recursion]
+package = "async-recursion"
+version = "=1.0.5"
 
 [dependencies.async_trait]
 package = "async-trait"
@@ -120,9 +143,19 @@ features = ["std"]
 package = "bitflags"
 version = "=1.3.2"
 
+[dependencies.bitvec]
+package = "bitvec"
+version = "=1.0.1"
+features = ["alloc", "atomic", "std"]
+
 [dependencies.block_buffer]
 package = "block-buffer"
 version = "=0.10.4"
+
+[dependencies.btoi]
+package = "btoi"
+version = "=0.4.3"
+features = ["std"]
 
 [dependencies.bytemuck]
 package = "bytemuck"
@@ -147,6 +180,10 @@ features = ["std"]
 package = "bytes"
 version = "=0.4.12"
 
+[dependencies.cast]
+package = "cast"
+version = "=0.3.0"
+
 [dependencies.cc]
 package = "cc"
 version = "=1.0.83"
@@ -159,6 +196,20 @@ version = "=1.0.0"
 package = "chrono"
 version = "=0.4.31"
 features = ["android-tzdata", "clock", "iana-time-zone", "js-sys", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-targets"]
+
+[dependencies.ciborium]
+package = "ciborium"
+version = "=0.2.1"
+features = ["std"]
+
+[dependencies.ciborium_io]
+package = "ciborium-io"
+version = "=0.2.1"
+features = ["alloc", "std"]
+
+[dependencies.ciborium_ll]
+package = "ciborium-ll"
+version = "=0.2.1"
 
 [dependencies.clap]
 package = "clap"
@@ -201,6 +252,11 @@ features = ["percent-encode", "percent-encoding"]
 package = "cookie_store"
 version = "=0.16.2"
 
+[dependencies.cpp_demangle]
+package = "cpp_demangle"
+version = "=0.4.3"
+features = ["alloc", "std"]
+
 [dependencies.cpufeatures]
 package = "cpufeatures"
 version = "=0.2.11"
@@ -209,6 +265,15 @@ version = "=0.2.11"
 package = "crc32fast"
 version = "=1.3.2"
 features = ["std"]
+
+[dependencies.criterion]
+package = "criterion"
+version = "=0.5.1"
+features = ["cargo_bench_support", "plotters", "rayon"]
+
+[dependencies.criterion_plot]
+package = "criterion-plot"
+version = "=0.5.0"
 
 [dependencies.crossbeam]
 package = "crossbeam"
@@ -254,6 +319,10 @@ version = "=1.3.0"
 package = "csv-core"
 version = "=0.1.11"
 
+[dependencies.dashmap]
+package = "dashmap"
+version = "=5.5.3"
+
 [dependencies.data_encoding]
 package = "data-encoding"
 version = "=2.5.0"
@@ -262,6 +331,10 @@ features = ["alloc", "std"]
 [dependencies.debug_unreachable]
 package = "new_debug_unreachable"
 version = "=1.0.4"
+
+[dependencies.debugid]
+package = "debugid"
+version = "=0.8.0"
 
 [dependencies.deranged]
 package = "deranged"
@@ -348,6 +421,10 @@ version = "=0.3.1"
 package = "filetime"
 version = "=0.2.23"
 
+[dependencies.findshlibs]
+package = "findshlibs"
+version = "=0.10.2"
+
 [dependencies.finl_unicode]
 package = "finl_unicode"
 version = "=1.2.0"
@@ -385,6 +462,11 @@ version = "=0.1.1"
 package = "form_urlencoded"
 version = "=1.2.1"
 features = ["alloc", "std"]
+
+[dependencies.funty]
+package = "funty"
+version = "=2.0.0"
+default-features = false
 
 [dependencies.futf]
 package = "futf"
@@ -482,6 +564,10 @@ version = "=0.3.22"
 package = "half"
 version = "=2.2.1"
 features = ["alloc", "std"]
+
+[dependencies.half_1_8_2]
+package = "half"
+version = "=1.8.2"
 
 [dependencies.hashbrown]
 package = "hashbrown"
@@ -606,6 +692,11 @@ package = "itertools"
 version = "=0.12.0"
 features = ["use_alloc", "use_std"]
 
+[dependencies.itertools_0_10_5]
+package = "itertools"
+version = "=0.10.5"
+features = ["use_alloc", "use_std"]
+
 [dependencies.itoa]
 package = "itoa"
 version = "=1.0.10"
@@ -702,6 +793,10 @@ features = ["alloc", "std"]
 package = "memmap"
 version = "=0.7.0"
 
+[dependencies.memmap2]
+package = "memmap2"
+version = "=0.9.3"
+
 [dependencies.memoffset]
 package = "memoffset"
 version = "=0.9.0"
@@ -748,6 +843,12 @@ version = "=0.2.11"
 package = "ndarray"
 version = "=0.15.6"
 features = ["std"]
+
+[dependencies.nix]
+package = "nix"
+version = "=0.26.4"
+features = ["fs", "process", "signal"]
+default-features = false
 
 [dependencies.nom]
 package = "nom"
@@ -808,6 +909,10 @@ package = "once_cell"
 version = "=1.19.0"
 features = ["alloc", "race", "std", "unstable"]
 
+[dependencies.oorandom]
+package = "oorandom"
+version = "=11.1.3"
+
 [dependencies.openssl]
 package = "openssl"
 version = "=0.10.61"
@@ -836,6 +941,10 @@ version = "=0.12.1"
 [dependencies.parking_lot_core]
 package = "parking_lot_core"
 version = "=0.9.9"
+
+[dependencies.parse]
+package = "parse"
+version = "=0.1.2"
 
 [dependencies.paste]
 package = "paste"
@@ -900,6 +1009,20 @@ version = "=0.1.0"
 package = "pkg-config"
 version = "=0.3.28"
 
+[dependencies.plotters]
+package = "plotters"
+version = "=0.3.5"
+features = ["area_series", "line_series", "plotters-svg", "svg_backend"]
+default-features = false
+
+[dependencies.plotters_backend]
+package = "plotters-backend"
+version = "=0.3.5"
+
+[dependencies.plotters_svg]
+package = "plotters-svg"
+version = "=0.3.5"
+
 [dependencies.png]
 package = "png"
 version = "=0.17.10"
@@ -920,6 +1043,11 @@ version = "=0.2.6"
 package = "powerfmt"
 version = "=0.2.0"
 default-features = false
+
+[dependencies.pprof]
+package = "pprof"
+version = "=0.13.0"
+features = ["cpp"]
 
 [dependencies.ppv_lite86]
 package = "ppv-lite86"
@@ -953,6 +1081,10 @@ features = ["std"]
 package = "quote"
 version = "=1.0.33"
 features = ["proc-macro"]
+
+[dependencies.radium]
+package = "radium"
+version = "=0.7.0"
 
 [dependencies.rand]
 package = "rand"
@@ -1140,6 +1272,11 @@ package = "spin"
 version = "=0.9.8"
 features = ["barrier", "lazy", "lock_api", "lock_api_crate", "mutex", "once", "rwlock", "spin_mutex"]
 
+[dependencies.stable_deref_trait]
+package = "stable_deref_trait"
+version = "=1.2.0"
+features = ["alloc", "std"]
+
 [dependencies.string_cache]
 package = "string_cache"
 version = "=0.8.7"
@@ -1162,6 +1299,16 @@ package = "subtle"
 version = "=2.5.0"
 default-features = false
 
+[dependencies.symbolic_common]
+package = "symbolic-common"
+version = "=12.8.0"
+
+[dependencies.symbolic_demangle]
+package = "symbolic-demangle"
+version = "=12.8.0"
+features = ["cpp", "cpp_demangle", "rust", "rustc-demangle"]
+default-features = false
+
 [dependencies.syn]
 package = "syn"
 version = "=2.0.42"
@@ -1171,6 +1318,10 @@ features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", 
 package = "syn"
 version = "=1.0.109"
 features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"]
+
+[dependencies.tap]
+package = "tap"
+version = "=1.0.1"
 
 [dependencies.tar]
 package = "tar"
@@ -1235,6 +1386,10 @@ version = "=0.1.2"
 package = "time-macros"
 version = "=0.2.16"
 features = ["formatting", "parsing"]
+
+[dependencies.tinytemplate]
+package = "tinytemplate"
+version = "=1.2.1"
 
 [dependencies.tinyvec]
 package = "tinyvec"
@@ -1416,6 +1571,11 @@ package = "winnow"
 version = "=0.5.30"
 features = ["alloc", "std"]
 
+[dependencies.wyz]
+package = "wyz"
+version = "=0.5.1"
+default-features = false
+
 [dependencies.xattr]
 package = "xattr"
 version = "=1.1.3"
@@ -1475,6 +1635,10 @@ version = "=0.2.16"
 features = ["alloc"]
 default-features = false
 
+[build_dependencies.anes]
+package = "anes"
+version = "=0.1.6"
+
 [build_dependencies.ansi_term]
 package = "ansi_term"
 version = "=0.12.1"
@@ -1511,6 +1675,20 @@ features = ["std"]
 [build_dependencies.arc_swap]
 package = "arc-swap"
 version = "=1.6.0"
+
+[build_dependencies.arrayvec]
+package = "arrayvec"
+version = "=0.7.4"
+features = ["std"]
+
+[build_dependencies.ascii]
+package = "ascii"
+version = "=1.1.0"
+features = ["alloc", "std"]
+
+[build_dependencies.async_recursion]
+package = "async-recursion"
+version = "=1.0.5"
 
 [build_dependencies.async_trait]
 package = "async-trait"
@@ -1563,9 +1741,19 @@ features = ["std"]
 package = "bitflags"
 version = "=1.3.2"
 
+[build_dependencies.bitvec]
+package = "bitvec"
+version = "=1.0.1"
+features = ["alloc", "atomic", "std"]
+
 [build_dependencies.block_buffer]
 package = "block-buffer"
 version = "=0.10.4"
+
+[build_dependencies.btoi]
+package = "btoi"
+version = "=0.4.3"
+features = ["std"]
 
 [build_dependencies.bytemuck]
 package = "bytemuck"
@@ -1590,6 +1778,10 @@ features = ["std"]
 package = "bytes"
 version = "=0.4.12"
 
+[build_dependencies.cast]
+package = "cast"
+version = "=0.3.0"
+
 [build_dependencies.cc]
 package = "cc"
 version = "=1.0.83"
@@ -1602,6 +1794,20 @@ version = "=1.0.0"
 package = "chrono"
 version = "=0.4.31"
 features = ["android-tzdata", "clock", "iana-time-zone", "js-sys", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-targets"]
+
+[build_dependencies.ciborium]
+package = "ciborium"
+version = "=0.2.1"
+features = ["std"]
+
+[build_dependencies.ciborium_io]
+package = "ciborium-io"
+version = "=0.2.1"
+features = ["alloc", "std"]
+
+[build_dependencies.ciborium_ll]
+package = "ciborium-ll"
+version = "=0.2.1"
 
 [build_dependencies.clap]
 package = "clap"
@@ -1644,6 +1850,11 @@ features = ["percent-encode", "percent-encoding"]
 package = "cookie_store"
 version = "=0.16.2"
 
+[build_dependencies.cpp_demangle]
+package = "cpp_demangle"
+version = "=0.4.3"
+features = ["alloc", "std"]
+
 [build_dependencies.cpufeatures]
 package = "cpufeatures"
 version = "=0.2.11"
@@ -1652,6 +1863,15 @@ version = "=0.2.11"
 package = "crc32fast"
 version = "=1.3.2"
 features = ["std"]
+
+[build_dependencies.criterion]
+package = "criterion"
+version = "=0.5.1"
+features = ["cargo_bench_support", "plotters", "rayon"]
+
+[build_dependencies.criterion_plot]
+package = "criterion-plot"
+version = "=0.5.0"
 
 [build_dependencies.crossbeam]
 package = "crossbeam"
@@ -1697,6 +1917,10 @@ version = "=1.3.0"
 package = "csv-core"
 version = "=0.1.11"
 
+[build_dependencies.dashmap]
+package = "dashmap"
+version = "=5.5.3"
+
 [build_dependencies.data_encoding]
 package = "data-encoding"
 version = "=2.5.0"
@@ -1705,6 +1929,10 @@ features = ["alloc", "std"]
 [build_dependencies.debug_unreachable]
 package = "new_debug_unreachable"
 version = "=1.0.4"
+
+[build_dependencies.debugid]
+package = "debugid"
+version = "=0.8.0"
 
 [build_dependencies.deranged]
 package = "deranged"
@@ -1791,6 +2019,10 @@ version = "=0.3.1"
 package = "filetime"
 version = "=0.2.23"
 
+[build_dependencies.findshlibs]
+package = "findshlibs"
+version = "=0.10.2"
+
 [build_dependencies.finl_unicode]
 package = "finl_unicode"
 version = "=1.2.0"
@@ -1828,6 +2060,11 @@ version = "=0.1.1"
 package = "form_urlencoded"
 version = "=1.2.1"
 features = ["alloc", "std"]
+
+[build_dependencies.funty]
+package = "funty"
+version = "=2.0.0"
+default-features = false
 
 [build_dependencies.futf]
 package = "futf"
@@ -1925,6 +2162,10 @@ version = "=0.3.22"
 package = "half"
 version = "=2.2.1"
 features = ["alloc", "std"]
+
+[build_dependencies.half_1_8_2]
+package = "half"
+version = "=1.8.2"
 
 [build_dependencies.hashbrown]
 package = "hashbrown"
@@ -2049,6 +2290,11 @@ package = "itertools"
 version = "=0.12.0"
 features = ["use_alloc", "use_std"]
 
+[build_dependencies.itertools_0_10_5]
+package = "itertools"
+version = "=0.10.5"
+features = ["use_alloc", "use_std"]
+
 [build_dependencies.itoa]
 package = "itoa"
 version = "=1.0.10"
@@ -2145,6 +2391,10 @@ features = ["alloc", "std"]
 package = "memmap"
 version = "=0.7.0"
 
+[build_dependencies.memmap2]
+package = "memmap2"
+version = "=0.9.3"
+
 [build_dependencies.memoffset]
 package = "memoffset"
 version = "=0.9.0"
@@ -2191,6 +2441,12 @@ version = "=0.2.11"
 package = "ndarray"
 version = "=0.15.6"
 features = ["std"]
+
+[build_dependencies.nix]
+package = "nix"
+version = "=0.26.4"
+features = ["fs", "process", "signal"]
+default-features = false
 
 [build_dependencies.nom]
 package = "nom"
@@ -2251,6 +2507,10 @@ package = "once_cell"
 version = "=1.19.0"
 features = ["alloc", "race", "std", "unstable"]
 
+[build_dependencies.oorandom]
+package = "oorandom"
+version = "=11.1.3"
+
 [build_dependencies.openssl]
 package = "openssl"
 version = "=0.10.61"
@@ -2279,6 +2539,10 @@ version = "=0.12.1"
 [build_dependencies.parking_lot_core]
 package = "parking_lot_core"
 version = "=0.9.9"
+
+[build_dependencies.parse]
+package = "parse"
+version = "=0.1.2"
 
 [build_dependencies.paste]
 package = "paste"
@@ -2343,6 +2607,20 @@ version = "=0.1.0"
 package = "pkg-config"
 version = "=0.3.28"
 
+[build_dependencies.plotters]
+package = "plotters"
+version = "=0.3.5"
+features = ["area_series", "line_series", "plotters-svg", "svg_backend"]
+default-features = false
+
+[build_dependencies.plotters_backend]
+package = "plotters-backend"
+version = "=0.3.5"
+
+[build_dependencies.plotters_svg]
+package = "plotters-svg"
+version = "=0.3.5"
+
 [build_dependencies.png]
 package = "png"
 version = "=0.17.10"
@@ -2363,6 +2641,11 @@ version = "=0.2.6"
 package = "powerfmt"
 version = "=0.2.0"
 default-features = false
+
+[build_dependencies.pprof]
+package = "pprof"
+version = "=0.13.0"
+features = ["cpp"]
 
 [build_dependencies.ppv_lite86]
 package = "ppv-lite86"
@@ -2396,6 +2679,10 @@ features = ["std"]
 package = "quote"
 version = "=1.0.33"
 features = ["proc-macro"]
+
+[build_dependencies.radium]
+package = "radium"
+version = "=0.7.0"
 
 [build_dependencies.rand]
 package = "rand"
@@ -2583,6 +2870,11 @@ package = "spin"
 version = "=0.9.8"
 features = ["barrier", "lazy", "lock_api", "lock_api_crate", "mutex", "once", "rwlock", "spin_mutex"]
 
+[build_dependencies.stable_deref_trait]
+package = "stable_deref_trait"
+version = "=1.2.0"
+features = ["alloc", "std"]
+
 [build_dependencies.string_cache]
 package = "string_cache"
 version = "=0.8.7"
@@ -2605,6 +2897,16 @@ package = "subtle"
 version = "=2.5.0"
 default-features = false
 
+[build_dependencies.symbolic_common]
+package = "symbolic-common"
+version = "=12.8.0"
+
+[build_dependencies.symbolic_demangle]
+package = "symbolic-demangle"
+version = "=12.8.0"
+features = ["cpp", "cpp_demangle", "rust", "rustc-demangle"]
+default-features = false
+
 [build_dependencies.syn]
 package = "syn"
 version = "=2.0.42"
@@ -2614,6 +2916,10 @@ features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", 
 package = "syn"
 version = "=1.0.109"
 features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"]
+
+[build_dependencies.tap]
+package = "tap"
+version = "=1.0.1"
 
 [build_dependencies.tar]
 package = "tar"
@@ -2678,6 +2984,10 @@ version = "=0.1.2"
 package = "time-macros"
 version = "=0.2.16"
 features = ["formatting", "parsing"]
+
+[build_dependencies.tinytemplate]
+package = "tinytemplate"
+version = "=1.2.1"
 
 [build_dependencies.tinyvec]
 package = "tinyvec"
@@ -2858,6 +3168,11 @@ default-features = false
 package = "winnow"
 version = "=0.5.30"
 features = ["alloc", "std"]
+
+[build_dependencies.wyz]
+package = "wyz"
+version = "=0.5.1"
+default-features = false
 
 [build_dependencies.xattr]
 package = "xattr"

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -3,13 +3,16 @@ name = "ferris-elf"
 version = "0.0.0"
 edition = "2021"
 
-[dev-dependencies]
-criterion = { version = "0.5.1" }
-pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
+[lib]
+path = "src/lib.rs"
 
 [[bench]]
 name = "bench"
 harness = false
+
+[dev-dependencies]
+criterion = { version = "0.5.1" }
+pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
 
 [dependencies.addr2line]
 package = "addr2line"
@@ -265,15 +268,6 @@ version = "=0.2.11"
 package = "crc32fast"
 version = "=1.3.2"
 features = ["std"]
-
-[dependencies.criterion]
-package = "criterion"
-version = "=0.5.1"
-features = ["cargo_bench_support", "plotters", "rayon"]
-
-[dependencies.criterion_plot]
-package = "criterion-plot"
-version = "=0.5.0"
 
 [dependencies.crossbeam]
 package = "crossbeam"
@@ -1044,11 +1038,6 @@ package = "powerfmt"
 version = "=0.2.0"
 default-features = false
 
-[dependencies.pprof]
-package = "pprof"
-version = "=0.13.0"
-features = ["cpp"]
-
 [dependencies.ppv_lite86]
 package = "ppv-lite86"
 version = "=0.2.17"
@@ -1565,6 +1554,14 @@ package = "wide"
 version = "=0.7.13"
 features = ["std"]
 default-features = false
+
+[dependencies.windows_targets]
+package = "windows-targets"
+version = "=0.52.0"
+
+[dependencies.windows_x86_64_gnu]
+package = "windows_x86_64_gnu"
+version = "=0.52.0"
 
 [dependencies.winnow]
 package = "winnow"
@@ -3163,6 +3160,14 @@ package = "wide"
 version = "=0.7.13"
 features = ["std"]
 default-features = false
+
+[build_dependencies.windows_targets]
+package = "windows-targets"
+version = "=0.52.0"
+
+[build_dependencies.windows_x86_64_gnu]
+package = "windows_x86_64_gnu"
+version = "=0.52.0"
 
 [build_dependencies.winnow]
 package = "winnow"

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -3,22 +3,6 @@ name = "ferris-elf"
 version = "0.0.0"
 edition = "2021"
 
-[dependencies]
-bytemuck = "1"
-itertools = "0.10"
-rayon = "1"
-regex = "1"
-parse-display = "0.6"
-memchr = "2"
-arrayvec = "0.7"
-smallvec = "1"
-rustc-hash = "1"
-bitvec = "1"
-dashmap = "5"
-btoi = "0.4"
-nom = "7"
-ascii = "1.1.0"
-
 [dev-dependencies]
 criterion = { version = "0.5.1" }
 pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
@@ -26,3 +10,2885 @@ pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
 [[bench]]
 name = "bench"
 harness = false
+
+[dependencies.adler]
+package = "adler"
+version = "=1.0.2"
+default-features = false
+
+[dependencies.ahash]
+package = "ahash"
+version = "=0.8.6"
+features = ["getrandom", "runtime-rng", "std"]
+
+[dependencies.aho_corasick]
+package = "aho-corasick"
+version = "=1.1.2"
+features = ["perf-literal", "std"]
+
+[dependencies.allocator_api2]
+package = "allocator-api2"
+version = "=0.2.16"
+features = ["alloc"]
+default-features = false
+
+[dependencies.ansi_term]
+package = "ansi_term"
+version = "=0.12.1"
+
+[dependencies.anstream]
+package = "anstream"
+version = "=0.6.5"
+features = ["auto", "wincon"]
+
+[dependencies.anstyle]
+package = "anstyle"
+version = "=1.0.4"
+features = ["std"]
+
+[dependencies.anstyle_parse]
+package = "anstyle-parse"
+version = "=0.2.3"
+features = ["utf8"]
+
+[dependencies.anstyle_query]
+package = "anstyle-query"
+version = "=1.0.2"
+
+[dependencies.anyhow]
+package = "anyhow"
+version = "=1.0.76"
+features = ["std"]
+
+[dependencies.approx]
+package = "approx"
+version = "=0.5.1"
+features = ["std"]
+
+[dependencies.arc_swap]
+package = "arc-swap"
+version = "=1.6.0"
+
+[dependencies.async_trait]
+package = "async-trait"
+version = "=0.1.75"
+
+[dependencies.atomic]
+package = "atomic"
+version = "=0.5.3"
+default-features = false
+
+[dependencies.atty]
+package = "atty"
+version = "=0.2.14"
+
+[dependencies.autocfg]
+package = "autocfg"
+version = "=1.1.0"
+
+[dependencies.backtrace]
+package = "backtrace"
+version = "=0.3.69"
+features = ["std"]
+
+[dependencies.base64]
+package = "base64"
+version = "=0.21.5"
+features = ["alloc", "std"]
+
+[dependencies.bit_field]
+package = "bit_field"
+version = "=0.10.2"
+
+[dependencies.bit_set]
+package = "bit-set"
+version = "=0.5.3"
+features = ["std"]
+
+[dependencies.bit_vec]
+package = "bit-vec"
+version = "=0.6.3"
+features = ["std"]
+default-features = false
+
+[dependencies.bitflags]
+package = "bitflags"
+version = "=2.4.1"
+features = ["std"]
+
+[dependencies.bitflags_1_3_2]
+package = "bitflags"
+version = "=1.3.2"
+
+[dependencies.block_buffer]
+package = "block-buffer"
+version = "=0.10.4"
+
+[dependencies.bytemuck]
+package = "bytemuck"
+version = "=1.14.0"
+features = ["bytemuck_derive", "derive", "extern_crate_alloc", "extern_crate_std", "min_const_generics", "must_cast", "wasm_simd", "zeroable_atomics", "zeroable_maybe_uninit"]
+
+[dependencies.bytemuck_derive]
+package = "bytemuck_derive"
+version = "=1.5.0"
+
+[dependencies.byteorder]
+package = "byteorder"
+version = "=1.5.0"
+features = ["std"]
+
+[dependencies.bytes]
+package = "bytes"
+version = "=1.5.0"
+features = ["std"]
+
+[dependencies.bytes_0_4_12]
+package = "bytes"
+version = "=0.4.12"
+
+[dependencies.cc]
+package = "cc"
+version = "=1.0.83"
+
+[dependencies.cfg_if]
+package = "cfg-if"
+version = "=1.0.0"
+
+[dependencies.chrono]
+package = "chrono"
+version = "=0.4.31"
+features = ["android-tzdata", "clock", "iana-time-zone", "js-sys", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-targets"]
+
+[dependencies.clap]
+package = "clap"
+version = "=4.4.11"
+features = ["color", "derive", "error-context", "help", "std", "suggestions", "unstable-doc", "usage"]
+
+[dependencies.clap_builder]
+package = "clap_builder"
+version = "=4.4.11"
+features = ["cargo", "color", "env", "error-context", "help", "std", "string", "suggestions", "unicode", "unstable-doc", "usage", "wrap_help"]
+default-features = false
+
+[dependencies.clap_derive]
+package = "clap_derive"
+version = "=4.4.7"
+
+[dependencies.clap_lex]
+package = "clap_lex"
+version = "=0.6.0"
+
+[dependencies.color_quant]
+package = "color_quant"
+version = "=1.1.0"
+
+[dependencies.colorchoice]
+package = "colorchoice"
+version = "=1.0.0"
+
+[dependencies.const_default]
+package = "const-default"
+version = "=1.0.0"
+default-features = false
+
+[dependencies.cookie]
+package = "cookie"
+version = "=0.16.2"
+features = ["percent-encode", "percent-encoding"]
+
+[dependencies.cookie_store]
+package = "cookie_store"
+version = "=0.16.2"
+
+[dependencies.cpufeatures]
+package = "cpufeatures"
+version = "=0.2.11"
+
+[dependencies.crc32fast]
+package = "crc32fast"
+version = "=1.3.2"
+features = ["std"]
+
+[dependencies.crossbeam]
+package = "crossbeam"
+version = "=0.8.2"
+features = ["alloc", "crossbeam-channel", "crossbeam-deque", "crossbeam-epoch", "crossbeam-queue", "std"]
+
+[dependencies.crossbeam_channel]
+package = "crossbeam-channel"
+version = "=0.5.9"
+features = ["crossbeam-utils", "std"]
+
+[dependencies.crossbeam_deque]
+package = "crossbeam-deque"
+version = "=0.8.4"
+features = ["crossbeam-epoch", "crossbeam-utils", "std"]
+
+[dependencies.crossbeam_epoch]
+package = "crossbeam-epoch"
+version = "=0.9.16"
+features = ["alloc", "std"]
+
+[dependencies.crossbeam_queue]
+package = "crossbeam-queue"
+version = "=0.3.9"
+features = ["alloc", "std"]
+default-features = false
+
+[dependencies.crossbeam_utils]
+package = "crossbeam-utils"
+version = "=0.8.17"
+features = ["std"]
+
+[dependencies.crypto_common]
+package = "crypto-common"
+version = "=0.1.6"
+features = ["std"]
+
+[dependencies.csv]
+package = "csv"
+version = "=1.3.0"
+
+[dependencies.csv_core]
+package = "csv-core"
+version = "=0.1.11"
+
+[dependencies.data_encoding]
+package = "data-encoding"
+version = "=2.5.0"
+features = ["alloc", "std"]
+
+[dependencies.debug_unreachable]
+package = "new_debug_unreachable"
+version = "=1.0.4"
+
+[dependencies.deranged]
+package = "deranged"
+version = "=0.3.10"
+features = ["alloc", "powerfmt", "std"]
+default-features = false
+
+[dependencies.derivative]
+package = "derivative"
+version = "=2.2.0"
+
+[dependencies.destructure_traitobject]
+package = "destructure_traitobject"
+version = "=0.2.0"
+
+[dependencies.digest]
+package = "digest"
+version = "=0.10.7"
+features = ["alloc", "block-buffer", "core-api", "mac", "std", "subtle"]
+
+[dependencies.either]
+package = "either"
+version = "=1.9.0"
+features = ["use_std"]
+
+[dependencies.encoding_rs]
+package = "encoding_rs"
+version = "=0.8.33"
+features = ["alloc"]
+
+[dependencies.env_logger]
+package = "env_logger"
+version = "=0.10.1"
+features = ["auto-color", "color", "humantime", "regex"]
+
+[dependencies.equivalent]
+package = "equivalent"
+version = "=1.0.1"
+
+[dependencies.errno]
+package = "errno"
+version = "=0.3.8"
+features = ["std"]
+default-features = false
+
+[dependencies.error_chain]
+package = "error-chain"
+version = "=0.12.4"
+features = ["backtrace", "example_generated"]
+
+[dependencies.exr]
+package = "exr"
+version = "=1.71.0"
+
+[dependencies.fallible_iterator]
+package = "fallible-iterator"
+version = "=0.3.0"
+features = ["alloc"]
+
+[dependencies.fallible_iterator_0_2_0]
+package = "fallible-iterator"
+version = "=0.2.0"
+features = ["std"]
+
+[dependencies.fallible_streaming_iterator]
+package = "fallible-streaming-iterator"
+version = "=0.1.9"
+
+[dependencies.faster_hex]
+package = "faster-hex"
+version = "=0.8.1"
+default-features = false
+
+[dependencies.fastrand]
+package = "fastrand"
+version = "=2.0.1"
+features = ["alloc", "std"]
+
+[dependencies.fdeflate]
+package = "fdeflate"
+version = "=0.3.1"
+
+[dependencies.filetime]
+package = "filetime"
+version = "=0.2.23"
+
+[dependencies.finl_unicode]
+package = "finl_unicode"
+version = "=1.2.0"
+features = ["categories", "grapheme_clusters"]
+
+[dependencies.fixedbitset]
+package = "fixedbitset"
+version = "=0.4.2"
+default-features = false
+
+[dependencies.flate2]
+package = "flate2"
+version = "=1.0.28"
+features = ["any_impl", "miniz_oxide", "rust_backend"]
+
+[dependencies.flume]
+package = "flume"
+version = "=0.11.0"
+default-features = false
+
+[dependencies.fnv]
+package = "fnv"
+version = "=1.0.7"
+features = ["std"]
+
+[dependencies.foreign_types]
+package = "foreign-types"
+version = "=0.3.2"
+
+[dependencies.foreign_types_shared]
+package = "foreign-types-shared"
+version = "=0.1.1"
+
+[dependencies.form_urlencoded]
+package = "form_urlencoded"
+version = "=1.2.1"
+features = ["alloc", "std"]
+
+[dependencies.futf]
+package = "futf"
+version = "=0.1.5"
+
+[dependencies.futures]
+package = "futures"
+version = "=0.3.29"
+features = ["alloc", "async-await", "compat", "executor", "futures-executor", "io-compat", "std", "thread-pool"]
+
+[dependencies.futures_0_1_31]
+package = "futures"
+version = "=0.1.31"
+features = ["use_std", "with-deprecated"]
+
+[dependencies.futures_channel]
+package = "futures-channel"
+version = "=0.3.29"
+features = ["alloc", "futures-sink", "sink", "std"]
+
+[dependencies.futures_core]
+package = "futures-core"
+version = "=0.3.29"
+features = ["alloc", "std"]
+
+[dependencies.futures_executor]
+package = "futures-executor"
+version = "=0.3.29"
+features = ["num_cpus", "std", "thread-pool"]
+default-features = false
+
+[dependencies.futures_io]
+package = "futures-io"
+version = "=0.3.29"
+features = ["std"]
+
+[dependencies.futures_macro]
+package = "futures-macro"
+version = "=0.3.29"
+
+[dependencies.futures_sink]
+package = "futures-sink"
+version = "=0.3.29"
+features = ["alloc", "std"]
+
+[dependencies.futures_task]
+package = "futures-task"
+version = "=0.3.29"
+features = ["alloc", "std"]
+
+[dependencies.futures_util]
+package = "futures-util"
+version = "=0.3.29"
+features = ["alloc", "async-await", "async-await-macro", "channel", "compat", "futures-channel", "futures-io", "futures-macro", "futures-sink", "futures_01", "io", "io-compat", "memchr", "sink", "slab", "std", "tokio-io"]
+
+[dependencies.generic_array]
+package = "generic-array"
+version = "=1.0.0"
+features = ["alloc", "const-default", "faster-hex", "internals", "serde", "zeroize"]
+
+[dependencies.generic_array_0_14_7]
+package = "generic-array"
+version = "=0.14.7"
+features = ["more_lengths"]
+
+[dependencies.getrandom]
+package = "getrandom"
+version = "=0.2.11"
+features = ["std"]
+
+[dependencies.gif]
+package = "gif"
+version = "=0.12.0"
+features = ["color_quant", "raii_no_panic", "std"]
+
+[dependencies.gimli]
+package = "gimli"
+version = "=0.28.1"
+features = ["read", "read-core"]
+default-features = false
+
+[dependencies.glob]
+package = "glob"
+version = "=0.3.1"
+
+[dependencies.h2]
+package = "h2"
+version = "=0.4.0"
+
+[dependencies.h2_0_3_22]
+package = "h2"
+version = "=0.3.22"
+
+[dependencies.half]
+package = "half"
+version = "=2.2.1"
+features = ["alloc", "std"]
+
+[dependencies.hashbrown]
+package = "hashbrown"
+version = "=0.14.3"
+features = ["ahash", "allocator-api2", "inline-more", "raw"]
+
+[dependencies.hashbrown_0_12_3]
+package = "hashbrown"
+version = "=0.12.3"
+features = ["raw"]
+default-features = false
+
+[dependencies.hashlink]
+package = "hashlink"
+version = "=0.8.4"
+
+[dependencies.heck]
+package = "heck"
+version = "=0.4.1"
+
+[dependencies.hmac]
+package = "hmac"
+version = "=0.12.1"
+
+[dependencies.html5ever]
+package = "html5ever"
+version = "=0.26.0"
+
+[dependencies.http]
+package = "http"
+version = "=1.0.0"
+features = ["std"]
+
+[dependencies.http_0_2_11]
+package = "http"
+version = "=0.2.11"
+
+[dependencies.http_body]
+package = "http-body"
+version = "=1.0.0"
+
+[dependencies.http_body_0_4_6]
+package = "http-body"
+version = "=0.4.6"
+
+[dependencies.httparse]
+package = "httparse"
+version = "=1.8.0"
+features = ["std"]
+
+[dependencies.httpdate]
+package = "httpdate"
+version = "=1.0.3"
+
+[dependencies.humantime]
+package = "humantime"
+version = "=2.1.0"
+
+[dependencies.hyper]
+package = "hyper"
+version = "=1.1.0"
+features = ["client", "full", "http1", "http2", "server"]
+
+[dependencies.hyper_0_14_28]
+package = "hyper"
+version = "=0.14.28"
+features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"]
+default-features = false
+
+[dependencies.hyper_tls]
+package = "hyper-tls"
+version = "=0.5.0"
+
+[dependencies.iana_time_zone]
+package = "iana-time-zone"
+version = "=0.1.58"
+features = ["fallback"]
+
+[dependencies.idna]
+package = "idna"
+version = "=0.5.0"
+features = ["alloc", "std"]
+
+[dependencies.idna_0_2_3]
+package = "idna"
+version = "=0.2.3"
+
+[dependencies.idna_0_3_0]
+package = "idna"
+version = "=0.3.0"
+
+[dependencies.image]
+package = "image"
+version = "=0.24.7"
+features = ["bmp", "dds", "dxt", "exr", "farbfeld", "gif", "hdr", "ico", "jpeg", "jpeg_rayon", "openexr", "png", "pnm", "qoi", "tga", "tiff", "webp"]
+
+[dependencies.indexmap]
+package = "indexmap"
+version = "=2.1.0"
+features = ["std"]
+
+[dependencies.indexmap_1_9_3]
+package = "indexmap"
+version = "=1.9.3"
+features = ["std"]
+
+[dependencies.iovec]
+package = "iovec"
+version = "=0.1.4"
+
+[dependencies.ipnet]
+package = "ipnet"
+version = "=2.9.0"
+features = ["std"]
+
+[dependencies.is_terminal]
+package = "is-terminal"
+version = "=0.4.9"
+
+[dependencies.itertools]
+package = "itertools"
+version = "=0.12.0"
+features = ["use_alloc", "use_std"]
+
+[dependencies.itoa]
+package = "itoa"
+version = "=1.0.10"
+
+[dependencies.jpeg_decoder]
+package = "jpeg-decoder"
+version = "=0.3.0"
+features = ["rayon"]
+default-features = false
+
+[dependencies.lazy_static]
+package = "lazy_static"
+version = "=1.4.0"
+
+[dependencies.lebe]
+package = "lebe"
+version = "=0.5.2"
+
+[dependencies.libc]
+package = "libc"
+version = "=0.2.151"
+features = ["extra_traits", "std"]
+
+[dependencies.libm]
+package = "libm"
+version = "=0.2.8"
+
+[dependencies.libsqlite3_sys]
+package = "libsqlite3-sys"
+version = "=0.27.0"
+features = ["bundled", "bundled_bindings", "cc", "min_sqlite_version_3_14_0", "pkg-config", "unlock_notify", "vcpkg"]
+
+[dependencies.linked_hash_map]
+package = "linked-hash-map"
+version = "=0.5.6"
+
+[dependencies.linux_raw_sys]
+package = "linux-raw-sys"
+version = "=0.4.12"
+features = ["elf", "errno", "general", "ioctl", "no_std", "std"]
+default-features = false
+
+[dependencies.lock_api]
+package = "lock_api"
+version = "=0.4.11"
+features = ["atomic_usize"]
+
+[dependencies.log]
+package = "log"
+version = "=0.4.20"
+features = ["serde", "std"]
+
+[dependencies.log4rs]
+package = "log4rs"
+version = "=1.2.0"
+features = ["all_components", "ansi_writer", "chrono", "compound_policy", "config_parsing", "console_appender", "console_writer", "delete_roller", "file_appender", "fixed_window_roller", "humantime", "json_encoder", "libc", "log-mdc", "parking_lot", "pattern_encoder", "rolling_file_appender", "serde", "serde-value", "serde_json", "serde_yaml", "simple_writer", "size_trigger", "thread-id", "threshold_filter", "typemap-ors", "winapi", "yaml_format"]
+
+[dependencies.log_mdc]
+package = "log-mdc"
+version = "=0.1.0"
+
+[dependencies.mac]
+package = "mac"
+version = "=0.1.1"
+
+[dependencies.markup5ever]
+package = "markup5ever"
+version = "=0.11.0"
+
+[dependencies.markup5ever_rcdom]
+package = "markup5ever_rcdom"
+version = "=0.2.0"
+
+[dependencies.matches]
+package = "matches"
+version = "=0.1.10"
+
+[dependencies.matrixmultiply]
+package = "matrixmultiply"
+version = "=0.3.8"
+features = ["cgemm", "std"]
+
+[dependencies.md5]
+package = "md-5"
+version = "=0.10.6"
+features = ["std"]
+
+[dependencies.memchr]
+package = "memchr"
+version = "=2.6.4"
+features = ["alloc", "std"]
+
+[dependencies.memmap]
+package = "memmap"
+version = "=0.7.0"
+
+[dependencies.memoffset]
+package = "memoffset"
+version = "=0.9.0"
+
+[dependencies.mime]
+package = "mime"
+version = "=0.3.17"
+
+[dependencies.mime_guess]
+package = "mime_guess"
+version = "=2.0.4"
+default-features = false
+
+[dependencies.minimal_lexical]
+package = "minimal-lexical"
+version = "=0.2.1"
+features = ["std"]
+default-features = false
+
+[dependencies.miniz_oxide]
+package = "miniz_oxide"
+version = "=0.7.1"
+features = ["simd", "simd-adler32", "with-alloc"]
+
+[dependencies.mio]
+package = "mio"
+version = "=0.8.10"
+features = ["log", "net", "os-ext", "os-poll"]
+
+[dependencies.nalgebra]
+package = "nalgebra"
+version = "=0.32.3"
+features = ["macros", "matrixmultiply", "nalgebra-macros", "std"]
+
+[dependencies.nalgebra_macros]
+package = "nalgebra-macros"
+version = "=0.2.1"
+
+[dependencies.native_tls]
+package = "native-tls"
+version = "=0.2.11"
+
+[dependencies.ndarray]
+package = "ndarray"
+version = "=0.15.6"
+features = ["std"]
+
+[dependencies.nom]
+package = "nom"
+version = "=7.1.3"
+features = ["alloc", "std"]
+
+[dependencies.num]
+package = "num"
+version = "=0.4.1"
+features = ["num-bigint", "std"]
+
+[dependencies.num_bigint]
+package = "num-bigint"
+version = "=0.4.4"
+features = ["std"]
+default-features = false
+
+[dependencies.num_complex]
+package = "num-complex"
+version = "=0.4.4"
+features = ["std"]
+default-features = false
+
+[dependencies.num_cpus]
+package = "num_cpus"
+version = "=1.16.0"
+
+[dependencies.num_integer]
+package = "num-integer"
+version = "=0.1.45"
+features = ["i128", "std"]
+
+[dependencies.num_iter]
+package = "num-iter"
+version = "=0.1.43"
+features = ["i128", "std"]
+default-features = false
+
+[dependencies.num_rational]
+package = "num-rational"
+version = "=0.4.1"
+features = ["num-bigint", "num-bigint-std", "std"]
+default-features = false
+
+[dependencies.num_traits]
+package = "num-traits"
+version = "=0.2.17"
+features = ["i128", "libm", "std"]
+
+[dependencies.object]
+package = "object"
+version = "=0.32.1"
+features = ["archive", "coff", "elf", "macho", "pe", "read_core", "unaligned"]
+default-features = false
+
+[dependencies.once_cell]
+package = "once_cell"
+version = "=1.19.0"
+features = ["alloc", "race", "std", "unstable"]
+
+[dependencies.openssl]
+package = "openssl"
+version = "=0.10.61"
+
+[dependencies.openssl_macros]
+package = "openssl-macros"
+version = "=0.1.1"
+
+[dependencies.openssl_probe]
+package = "openssl-probe"
+version = "=0.1.5"
+
+[dependencies.openssl_sys]
+package = "openssl-sys"
+version = "=0.9.97"
+
+[dependencies.ordered_float]
+package = "ordered-float"
+version = "=2.10.1"
+features = ["std"]
+
+[dependencies.parking_lot]
+package = "parking_lot"
+version = "=0.12.1"
+
+[dependencies.parking_lot_core]
+package = "parking_lot_core"
+version = "=0.9.9"
+
+[dependencies.paste]
+package = "paste"
+version = "=1.0.14"
+
+[dependencies.percent_encoding]
+package = "percent-encoding"
+version = "=2.3.1"
+features = ["alloc", "std"]
+
+[dependencies.petgraph]
+package = "petgraph"
+version = "=0.6.4"
+features = ["graphmap", "matrix_graph", "stable_graph"]
+
+[dependencies.phf]
+package = "phf"
+version = "=0.11.2"
+features = ["macros", "phf_macros", "std"]
+
+[dependencies.phf_0_10_1]
+package = "phf"
+version = "=0.10.1"
+features = ["std"]
+
+[dependencies.phf_codegen]
+package = "phf_codegen"
+version = "=0.10.0"
+
+[dependencies.phf_generator]
+package = "phf_generator"
+version = "=0.11.2"
+
+[dependencies.phf_generator_0_10_0]
+package = "phf_generator"
+version = "=0.10.0"
+
+[dependencies.phf_macros]
+package = "phf_macros"
+version = "=0.11.2"
+
+[dependencies.phf_shared]
+package = "phf_shared"
+version = "=0.11.2"
+features = ["std"]
+default-features = false
+
+[dependencies.phf_shared_0_10_0]
+package = "phf_shared"
+version = "=0.10.0"
+features = ["std"]
+
+[dependencies.pin_project_lite]
+package = "pin-project-lite"
+version = "=0.2.13"
+
+[dependencies.pin_utils]
+package = "pin-utils"
+version = "=0.1.0"
+
+[dependencies.pkg_config]
+package = "pkg-config"
+version = "=0.3.28"
+
+[dependencies.png]
+package = "png"
+version = "=0.17.10"
+
+[dependencies.postgres]
+package = "postgres"
+version = "=0.19.7"
+
+[dependencies.postgres_protocol]
+package = "postgres-protocol"
+version = "=0.6.6"
+
+[dependencies.postgres_types]
+package = "postgres-types"
+version = "=0.2.6"
+
+[dependencies.powerfmt]
+package = "powerfmt"
+version = "=0.2.0"
+default-features = false
+
+[dependencies.ppv_lite86]
+package = "ppv-lite86"
+version = "=0.2.17"
+features = ["simd", "std"]
+
+[dependencies.precomputed_hash]
+package = "precomputed-hash"
+version = "=0.1.1"
+
+[dependencies.proc_macro2]
+package = "proc-macro2"
+version = "=1.0.71"
+features = ["proc-macro", "span-locations"]
+
+[dependencies.psl_types]
+package = "psl-types"
+version = "=2.0.11"
+
+[dependencies.publicsuffix]
+package = "publicsuffix"
+version = "=2.2.3"
+features = ["idna", "punycode"]
+
+[dependencies.qoi]
+package = "qoi"
+version = "=0.4.1"
+features = ["std"]
+
+[dependencies.quote]
+package = "quote"
+version = "=1.0.33"
+features = ["proc-macro"]
+
+[dependencies.rand]
+package = "rand"
+version = "=0.8.5"
+features = ["alloc", "getrandom", "libc", "rand_chacha", "serde", "serde1", "small_rng", "std", "std_rng"]
+
+[dependencies.rand_chacha]
+package = "rand_chacha"
+version = "=0.3.1"
+features = ["std"]
+
+[dependencies.rand_core]
+package = "rand_core"
+version = "=0.6.4"
+features = ["alloc", "getrandom", "serde", "serde1", "std"]
+
+[dependencies.rand_distr]
+package = "rand_distr"
+version = "=0.4.3"
+features = ["alloc", "std"]
+
+[dependencies.rawpointer]
+package = "rawpointer"
+version = "=0.2.1"
+
+[dependencies.rayon]
+package = "rayon"
+version = "=1.8.0"
+
+[dependencies.rayon_core]
+package = "rayon-core"
+version = "=1.12.0"
+
+[dependencies.regex]
+package = "regex"
+version = "=1.10.2"
+features = ["perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
+
+[dependencies.regex_automata]
+package = "regex-automata"
+version = "=0.4.3"
+features = ["alloc", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "nfa-pikevm", "nfa-thompson", "perf-inline", "perf-literal", "perf-literal-multisubstring", "perf-literal-substring", "std", "syntax", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment", "unicode-word-boundary"]
+default-features = false
+
+[dependencies.regex_syntax]
+package = "regex-syntax"
+version = "=0.8.2"
+features = ["std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
+
+[dependencies.reqwest]
+package = "reqwest"
+version = "=0.11.23"
+features = ["__tls", "blocking", "cookie_crate", "cookie_store", "cookies", "default-tls", "hyper-tls", "json", "mime_guess", "multipart", "native-tls-crate", "serde_json", "tokio-native-tls"]
+
+[dependencies.ring]
+package = "ring"
+version = "=0.17.7"
+features = ["alloc", "dev_urandom_fallback"]
+
+[dependencies.rusqlite]
+package = "rusqlite"
+version = "=0.30.0"
+features = ["array", "backup", "blob", "bundled", "bundled-full", "chrono", "collation", "column_decltype", "csv", "csvtab", "extra_check", "functions", "hooks", "i128_blob", "limits", "load_extension", "modern-full", "modern_sqlite", "serde_json", "series", "time", "trace", "unlock_notify", "url", "uuid", "vtab", "window"]
+
+[dependencies.rustc_demangle]
+package = "rustc-demangle"
+version = "=0.1.23"
+
+[dependencies.rustc_version]
+package = "rustc_version"
+version = "=0.4.0"
+
+[dependencies.rustix]
+package = "rustix"
+version = "=0.38.28"
+features = ["alloc", "fs", "std", "termios", "use-libc-auxv"]
+
+[dependencies.ryu]
+package = "ryu"
+version = "=1.0.16"
+
+[dependencies.safe_arch]
+package = "safe_arch"
+version = "=0.7.1"
+features = ["bytemuck"]
+
+[dependencies.same_file]
+package = "same-file"
+version = "=1.0.6"
+
+[dependencies.scopeguard]
+package = "scopeguard"
+version = "=1.2.0"
+features = ["use_std"]
+
+[dependencies.select]
+package = "select"
+version = "=0.6.0"
+
+[dependencies.semver]
+package = "semver"
+version = "=1.0.20"
+features = ["std"]
+
+[dependencies.serde]
+package = "serde"
+version = "=1.0.193"
+features = ["alloc", "derive", "rc", "serde_derive", "std"]
+
+[dependencies.serde_derive]
+package = "serde_derive"
+version = "=1.0.193"
+
+[dependencies.serde_json]
+package = "serde_json"
+version = "=1.0.108"
+features = ["raw_value", "std"]
+
+[dependencies.serde_spanned]
+package = "serde_spanned"
+version = "=0.6.5"
+features = ["serde"]
+
+[dependencies.serde_urlencoded]
+package = "serde_urlencoded"
+version = "=0.7.1"
+
+[dependencies.serde_value]
+package = "serde-value"
+version = "=0.7.0"
+
+[dependencies.serde_yaml]
+package = "serde_yaml"
+version = "=0.8.26"
+
+[dependencies.sha1_smol]
+package = "sha1_smol"
+version = "=1.0.0"
+
+[dependencies.sha2]
+package = "sha2"
+version = "=0.10.8"
+features = ["std"]
+
+[dependencies.signal_hook_registry]
+package = "signal-hook-registry"
+version = "=1.4.1"
+
+[dependencies.simba]
+package = "simba"
+version = "=0.8.1"
+features = ["std", "wide"]
+default-features = false
+
+[dependencies.simd_adler32]
+package = "simd-adler32"
+version = "=0.3.7"
+features = ["const-generics", "std"]
+
+[dependencies.siphasher]
+package = "siphasher"
+version = "=0.3.11"
+features = ["std"]
+
+[dependencies.slab]
+package = "slab"
+version = "=0.4.9"
+features = ["std"]
+
+[dependencies.smallvec]
+package = "smallvec"
+version = "=1.11.2"
+
+[dependencies.smawk]
+package = "smawk"
+version = "=0.3.2"
+
+[dependencies.socket2]
+package = "socket2"
+version = "=0.5.5"
+features = ["all"]
+
+[dependencies.spin]
+package = "spin"
+version = "=0.9.8"
+features = ["barrier", "lazy", "lock_api", "lock_api_crate", "mutex", "once", "rwlock", "spin_mutex"]
+
+[dependencies.string_cache]
+package = "string_cache"
+version = "=0.8.7"
+features = ["serde", "serde_support"]
+
+[dependencies.string_cache_codegen]
+package = "string_cache_codegen"
+version = "=0.5.2"
+
+[dependencies.stringprep]
+package = "stringprep"
+version = "=0.1.4"
+
+[dependencies.strsim]
+package = "strsim"
+version = "=0.10.0"
+
+[dependencies.subtle]
+package = "subtle"
+version = "=2.5.0"
+default-features = false
+
+[dependencies.syn]
+package = "syn"
+version = "=2.0.42"
+features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"]
+
+[dependencies.syn_1_0_109]
+package = "syn"
+version = "=1.0.109"
+features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"]
+
+[dependencies.tar]
+package = "tar"
+version = "=0.4.40"
+features = ["xattr"]
+
+[dependencies.tempfile]
+package = "tempfile"
+version = "=3.8.1"
+
+[dependencies.tendril]
+package = "tendril"
+version = "=0.4.3"
+
+[dependencies.termcolor]
+package = "termcolor"
+version = "=1.4.0"
+
+[dependencies.terminal_size]
+package = "terminal_size"
+version = "=0.3.0"
+
+[dependencies.textwrap]
+package = "textwrap"
+version = "=0.16.0"
+features = ["smawk", "unicode-linebreak", "unicode-width"]
+
+[dependencies.thiserror]
+package = "thiserror"
+version = "=1.0.51"
+
+[dependencies.thiserror_impl]
+package = "thiserror-impl"
+version = "=1.0.51"
+
+[dependencies.thread_id]
+package = "thread-id"
+version = "=4.2.1"
+
+[dependencies.thread_local]
+package = "thread_local"
+version = "=1.1.7"
+
+[dependencies.threadpool]
+package = "threadpool"
+version = "=1.8.1"
+
+[dependencies.tiff]
+package = "tiff"
+version = "=0.9.0"
+
+[dependencies.time]
+package = "time"
+version = "=0.3.31"
+features = ["alloc", "formatting", "macros", "parsing", "std"]
+
+[dependencies.time_core]
+package = "time-core"
+version = "=0.1.2"
+
+[dependencies.time_macros]
+package = "time-macros"
+version = "=0.2.16"
+features = ["formatting", "parsing"]
+
+[dependencies.tinyvec]
+package = "tinyvec"
+version = "=1.6.0"
+features = ["alloc", "grab_spare_slice", "rustc_1_40", "rustc_1_55", "serde", "std", "tinyvec_macros"]
+
+[dependencies.tinyvec_macros]
+package = "tinyvec_macros"
+version = "=0.1.1"
+
+[dependencies.tokio]
+package = "tokio"
+version = "=1.35.1"
+features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "num_cpus", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros", "windows-sys"]
+
+[dependencies.tokio_io]
+package = "tokio-io"
+version = "=0.1.13"
+
+[dependencies.tokio_macros]
+package = "tokio-macros"
+version = "=2.2.0"
+
+[dependencies.tokio_native_tls]
+package = "tokio-native-tls"
+version = "=0.3.1"
+
+[dependencies.tokio_postgres]
+package = "tokio-postgres"
+version = "=0.7.10"
+features = ["runtime"]
+
+[dependencies.tokio_util]
+package = "tokio-util"
+version = "=0.7.10"
+features = ["codec", "io", "tracing"]
+
+[dependencies.toml]
+package = "toml"
+version = "=0.8.8"
+features = ["display", "parse"]
+
+[dependencies.toml_datetime]
+package = "toml_datetime"
+version = "=0.6.5"
+features = ["serde"]
+
+[dependencies.toml_edit]
+package = "toml_edit"
+version = "=0.21.0"
+features = ["display", "parse", "serde"]
+default-features = false
+
+[dependencies.tower_service]
+package = "tower-service"
+version = "=0.3.2"
+
+[dependencies.tracing]
+package = "tracing"
+version = "=0.1.40"
+features = ["attributes", "std", "tracing-attributes"]
+
+[dependencies.tracing_attributes]
+package = "tracing-attributes"
+version = "=0.1.27"
+
+[dependencies.tracing_core]
+package = "tracing-core"
+version = "=0.1.32"
+features = ["once_cell", "std", "valuable"]
+
+[dependencies.try_lock]
+package = "try-lock"
+version = "=0.2.5"
+
+[dependencies.typemap_ors]
+package = "typemap-ors"
+version = "=1.0.0"
+
+[dependencies.typenum]
+package = "typenum"
+version = "=1.17.0"
+features = ["const-generics", "i128"]
+
+[dependencies.unicase]
+package = "unicase"
+version = "=2.7.0"
+
+[dependencies.unicode_bidi]
+package = "unicode-bidi"
+version = "=0.3.14"
+features = ["hardcoded-data", "std"]
+
+[dependencies.unicode_ident]
+package = "unicode-ident"
+version = "=1.0.12"
+
+[dependencies.unicode_linebreak]
+package = "unicode-linebreak"
+version = "=0.1.5"
+
+[dependencies.unicode_normalization]
+package = "unicode-normalization"
+version = "=0.1.22"
+features = ["std"]
+
+[dependencies.unicode_segmentation]
+package = "unicode-segmentation"
+version = "=1.10.1"
+
+[dependencies.unicode_width]
+package = "unicode-width"
+version = "=0.1.11"
+
+[dependencies.unicode_xid]
+package = "unicode-xid"
+version = "=0.2.4"
+
+[dependencies.unsafe_any_ors]
+package = "unsafe-any-ors"
+version = "=1.0.0"
+
+[dependencies.untrusted]
+package = "untrusted"
+version = "=0.9.0"
+
+[dependencies.url]
+package = "url"
+version = "=2.5.0"
+features = ["serde"]
+
+[dependencies.utf8]
+package = "utf-8"
+version = "=0.7.6"
+
+[dependencies.utf8parse]
+package = "utf8parse"
+version = "=0.2.1"
+
+[dependencies.uuid]
+package = "uuid"
+version = "=1.6.1"
+features = ["atomic", "getrandom", "md-5", "md5", "rng", "serde", "sha1", "sha1_smol", "std", "v1", "v3", "v4", "v5", "v6", "v7", "v8"]
+
+[dependencies.vcpkg]
+package = "vcpkg"
+version = "=0.2.15"
+
+[dependencies.version_check]
+package = "version_check"
+version = "=0.9.4"
+
+[dependencies.walkdir]
+package = "walkdir"
+version = "=2.4.0"
+
+[dependencies.want]
+package = "want"
+version = "=0.3.1"
+
+[dependencies.weezl]
+package = "weezl"
+version = "=0.1.7"
+features = ["alloc", "std"]
+
+[dependencies.whoami]
+package = "whoami"
+version = "=1.4.1"
+features = ["wasm-bindgen", "web", "web-sys"]
+
+[dependencies.wide]
+package = "wide"
+version = "=0.7.13"
+features = ["std"]
+default-features = false
+
+[dependencies.winnow]
+package = "winnow"
+version = "=0.5.30"
+features = ["alloc", "std"]
+
+[dependencies.xattr]
+package = "xattr"
+version = "=1.1.3"
+features = ["unsupported"]
+
+[dependencies.xml5ever]
+package = "xml5ever"
+version = "=0.17.0"
+
+[dependencies.yaml_rust]
+package = "yaml-rust"
+version = "=0.4.5"
+
+[dependencies.zerocopy]
+package = "zerocopy"
+version = "=0.7.32"
+features = ["__internal_use_only_features_that_work_on_stable", "alloc", "derive", "simd", "zerocopy-derive"]
+default-features = false
+
+[dependencies.zerocopy_derive]
+package = "zerocopy-derive"
+version = "=0.7.32"
+
+[dependencies.zeroize]
+package = "zeroize"
+version = "=1.7.0"
+default-features = false
+
+[dependencies.zune_inflate]
+package = "zune-inflate"
+version = "=0.2.54"
+features = ["simd-adler32", "zlib"]
+default-features = false
+[build_dependencies.addr2line]
+package = "addr2line"
+version = "=0.21.0"
+default-features = false
+
+[build_dependencies.adler]
+package = "adler"
+version = "=1.0.2"
+default-features = false
+
+[build_dependencies.ahash]
+package = "ahash"
+version = "=0.8.6"
+features = ["getrandom", "runtime-rng", "std"]
+
+[build_dependencies.aho_corasick]
+package = "aho-corasick"
+version = "=1.1.2"
+features = ["perf-literal", "std"]
+
+[build_dependencies.allocator_api2]
+package = "allocator-api2"
+version = "=0.2.16"
+features = ["alloc"]
+default-features = false
+
+[build_dependencies.ansi_term]
+package = "ansi_term"
+version = "=0.12.1"
+
+[build_dependencies.anstream]
+package = "anstream"
+version = "=0.6.5"
+features = ["auto", "wincon"]
+
+[build_dependencies.anstyle]
+package = "anstyle"
+version = "=1.0.4"
+features = ["std"]
+
+[build_dependencies.anstyle_parse]
+package = "anstyle-parse"
+version = "=0.2.3"
+features = ["utf8"]
+
+[build_dependencies.anstyle_query]
+package = "anstyle-query"
+version = "=1.0.2"
+
+[build_dependencies.anyhow]
+package = "anyhow"
+version = "=1.0.76"
+features = ["std"]
+
+[build_dependencies.approx]
+package = "approx"
+version = "=0.5.1"
+features = ["std"]
+
+[build_dependencies.arc_swap]
+package = "arc-swap"
+version = "=1.6.0"
+
+[build_dependencies.async_trait]
+package = "async-trait"
+version = "=0.1.75"
+
+[build_dependencies.atomic]
+package = "atomic"
+version = "=0.5.3"
+default-features = false
+
+[build_dependencies.atty]
+package = "atty"
+version = "=0.2.14"
+
+[build_dependencies.autocfg]
+package = "autocfg"
+version = "=1.1.0"
+
+[build_dependencies.backtrace]
+package = "backtrace"
+version = "=0.3.69"
+features = ["std"]
+
+[build_dependencies.base64]
+package = "base64"
+version = "=0.21.5"
+features = ["alloc", "std"]
+
+[build_dependencies.bit_field]
+package = "bit_field"
+version = "=0.10.2"
+
+[build_dependencies.bit_set]
+package = "bit-set"
+version = "=0.5.3"
+features = ["std"]
+
+[build_dependencies.bit_vec]
+package = "bit-vec"
+version = "=0.6.3"
+features = ["std"]
+default-features = false
+
+[build_dependencies.bitflags]
+package = "bitflags"
+version = "=2.4.1"
+features = ["std"]
+
+[build_dependencies.bitflags_1_3_2]
+package = "bitflags"
+version = "=1.3.2"
+
+[build_dependencies.block_buffer]
+package = "block-buffer"
+version = "=0.10.4"
+
+[build_dependencies.bytemuck]
+package = "bytemuck"
+version = "=1.14.0"
+features = ["bytemuck_derive", "derive", "extern_crate_alloc", "extern_crate_std", "min_const_generics", "must_cast", "wasm_simd", "zeroable_atomics", "zeroable_maybe_uninit"]
+
+[build_dependencies.bytemuck_derive]
+package = "bytemuck_derive"
+version = "=1.5.0"
+
+[build_dependencies.byteorder]
+package = "byteorder"
+version = "=1.5.0"
+features = ["std"]
+
+[build_dependencies.bytes]
+package = "bytes"
+version = "=1.5.0"
+features = ["std"]
+
+[build_dependencies.bytes_0_4_12]
+package = "bytes"
+version = "=0.4.12"
+
+[build_dependencies.cc]
+package = "cc"
+version = "=1.0.83"
+
+[build_dependencies.cfg_if]
+package = "cfg-if"
+version = "=1.0.0"
+
+[build_dependencies.chrono]
+package = "chrono"
+version = "=0.4.31"
+features = ["android-tzdata", "clock", "iana-time-zone", "js-sys", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-targets"]
+
+[build_dependencies.clap]
+package = "clap"
+version = "=4.4.11"
+features = ["color", "derive", "error-context", "help", "std", "suggestions", "unstable-doc", "usage"]
+
+[build_dependencies.clap_builder]
+package = "clap_builder"
+version = "=4.4.11"
+features = ["cargo", "color", "env", "error-context", "help", "std", "string", "suggestions", "unicode", "unstable-doc", "usage", "wrap_help"]
+default-features = false
+
+[build_dependencies.clap_derive]
+package = "clap_derive"
+version = "=4.4.7"
+
+[build_dependencies.clap_lex]
+package = "clap_lex"
+version = "=0.6.0"
+
+[build_dependencies.color_quant]
+package = "color_quant"
+version = "=1.1.0"
+
+[build_dependencies.colorchoice]
+package = "colorchoice"
+version = "=1.0.0"
+
+[build_dependencies.const_default]
+package = "const-default"
+version = "=1.0.0"
+default-features = false
+
+[build_dependencies.cookie]
+package = "cookie"
+version = "=0.16.2"
+features = ["percent-encode", "percent-encoding"]
+
+[build_dependencies.cookie_store]
+package = "cookie_store"
+version = "=0.16.2"
+
+[build_dependencies.cpufeatures]
+package = "cpufeatures"
+version = "=0.2.11"
+
+[build_dependencies.crc32fast]
+package = "crc32fast"
+version = "=1.3.2"
+features = ["std"]
+
+[build_dependencies.crossbeam]
+package = "crossbeam"
+version = "=0.8.2"
+features = ["alloc", "crossbeam-channel", "crossbeam-deque", "crossbeam-epoch", "crossbeam-queue", "std"]
+
+[build_dependencies.crossbeam_channel]
+package = "crossbeam-channel"
+version = "=0.5.9"
+features = ["crossbeam-utils", "std"]
+
+[build_dependencies.crossbeam_deque]
+package = "crossbeam-deque"
+version = "=0.8.4"
+features = ["crossbeam-epoch", "crossbeam-utils", "std"]
+
+[build_dependencies.crossbeam_epoch]
+package = "crossbeam-epoch"
+version = "=0.9.16"
+features = ["alloc", "std"]
+
+[build_dependencies.crossbeam_queue]
+package = "crossbeam-queue"
+version = "=0.3.9"
+features = ["alloc", "std"]
+default-features = false
+
+[build_dependencies.crossbeam_utils]
+package = "crossbeam-utils"
+version = "=0.8.17"
+features = ["std"]
+
+[build_dependencies.crypto_common]
+package = "crypto-common"
+version = "=0.1.6"
+features = ["std"]
+
+[build_dependencies.csv]
+package = "csv"
+version = "=1.3.0"
+
+[build_dependencies.csv_core]
+package = "csv-core"
+version = "=0.1.11"
+
+[build_dependencies.data_encoding]
+package = "data-encoding"
+version = "=2.5.0"
+features = ["alloc", "std"]
+
+[build_dependencies.debug_unreachable]
+package = "new_debug_unreachable"
+version = "=1.0.4"
+
+[build_dependencies.deranged]
+package = "deranged"
+version = "=0.3.10"
+features = ["alloc", "powerfmt", "std"]
+default-features = false
+
+[build_dependencies.derivative]
+package = "derivative"
+version = "=2.2.0"
+
+[build_dependencies.destructure_traitobject]
+package = "destructure_traitobject"
+version = "=0.2.0"
+
+[build_dependencies.digest]
+package = "digest"
+version = "=0.10.7"
+features = ["alloc", "block-buffer", "core-api", "mac", "std", "subtle"]
+
+[build_dependencies.either]
+package = "either"
+version = "=1.9.0"
+features = ["use_std"]
+
+[build_dependencies.encoding_rs]
+package = "encoding_rs"
+version = "=0.8.33"
+features = ["alloc"]
+
+[build_dependencies.env_logger]
+package = "env_logger"
+version = "=0.10.1"
+features = ["auto-color", "color", "humantime", "regex"]
+
+[build_dependencies.equivalent]
+package = "equivalent"
+version = "=1.0.1"
+
+[build_dependencies.errno]
+package = "errno"
+version = "=0.3.8"
+features = ["std"]
+default-features = false
+
+[build_dependencies.error_chain]
+package = "error-chain"
+version = "=0.12.4"
+features = ["backtrace", "example_generated"]
+
+[build_dependencies.exr]
+package = "exr"
+version = "=1.71.0"
+
+[build_dependencies.fallible_iterator]
+package = "fallible-iterator"
+version = "=0.3.0"
+features = ["alloc"]
+
+[build_dependencies.fallible_iterator_0_2_0]
+package = "fallible-iterator"
+version = "=0.2.0"
+features = ["std"]
+
+[build_dependencies.fallible_streaming_iterator]
+package = "fallible-streaming-iterator"
+version = "=0.1.9"
+
+[build_dependencies.faster_hex]
+package = "faster-hex"
+version = "=0.8.1"
+default-features = false
+
+[build_dependencies.fastrand]
+package = "fastrand"
+version = "=2.0.1"
+features = ["alloc", "std"]
+
+[build_dependencies.fdeflate]
+package = "fdeflate"
+version = "=0.3.1"
+
+[build_dependencies.filetime]
+package = "filetime"
+version = "=0.2.23"
+
+[build_dependencies.finl_unicode]
+package = "finl_unicode"
+version = "=1.2.0"
+features = ["categories", "grapheme_clusters"]
+
+[build_dependencies.fixedbitset]
+package = "fixedbitset"
+version = "=0.4.2"
+default-features = false
+
+[build_dependencies.flate2]
+package = "flate2"
+version = "=1.0.28"
+features = ["any_impl", "miniz_oxide", "rust_backend"]
+
+[build_dependencies.flume]
+package = "flume"
+version = "=0.11.0"
+default-features = false
+
+[build_dependencies.fnv]
+package = "fnv"
+version = "=1.0.7"
+features = ["std"]
+
+[build_dependencies.foreign_types]
+package = "foreign-types"
+version = "=0.3.2"
+
+[build_dependencies.foreign_types_shared]
+package = "foreign-types-shared"
+version = "=0.1.1"
+
+[build_dependencies.form_urlencoded]
+package = "form_urlencoded"
+version = "=1.2.1"
+features = ["alloc", "std"]
+
+[build_dependencies.futf]
+package = "futf"
+version = "=0.1.5"
+
+[build_dependencies.futures]
+package = "futures"
+version = "=0.3.29"
+features = ["alloc", "async-await", "compat", "executor", "futures-executor", "io-compat", "std", "thread-pool"]
+
+[build_dependencies.futures_0_1_31]
+package = "futures"
+version = "=0.1.31"
+features = ["use_std", "with-deprecated"]
+
+[build_dependencies.futures_channel]
+package = "futures-channel"
+version = "=0.3.29"
+features = ["alloc", "futures-sink", "sink", "std"]
+
+[build_dependencies.futures_core]
+package = "futures-core"
+version = "=0.3.29"
+features = ["alloc", "std"]
+
+[build_dependencies.futures_executor]
+package = "futures-executor"
+version = "=0.3.29"
+features = ["num_cpus", "std", "thread-pool"]
+default-features = false
+
+[build_dependencies.futures_io]
+package = "futures-io"
+version = "=0.3.29"
+features = ["std"]
+
+[build_dependencies.futures_macro]
+package = "futures-macro"
+version = "=0.3.29"
+
+[build_dependencies.futures_sink]
+package = "futures-sink"
+version = "=0.3.29"
+features = ["alloc", "std"]
+
+[build_dependencies.futures_task]
+package = "futures-task"
+version = "=0.3.29"
+features = ["alloc", "std"]
+
+[build_dependencies.futures_util]
+package = "futures-util"
+version = "=0.3.29"
+features = ["alloc", "async-await", "async-await-macro", "channel", "compat", "futures-channel", "futures-io", "futures-macro", "futures-sink", "futures_01", "io", "io-compat", "memchr", "sink", "slab", "std", "tokio-io"]
+
+[build_dependencies.generic_array]
+package = "generic-array"
+version = "=1.0.0"
+features = ["alloc", "const-default", "faster-hex", "internals", "serde", "zeroize"]
+
+[build_dependencies.generic_array_0_14_7]
+package = "generic-array"
+version = "=0.14.7"
+features = ["more_lengths"]
+
+[build_dependencies.getrandom]
+package = "getrandom"
+version = "=0.2.11"
+features = ["std"]
+
+[build_dependencies.gif]
+package = "gif"
+version = "=0.12.0"
+features = ["color_quant", "raii_no_panic", "std"]
+
+[build_dependencies.gimli]
+package = "gimli"
+version = "=0.28.1"
+features = ["read", "read-core"]
+default-features = false
+
+[build_dependencies.glob]
+package = "glob"
+version = "=0.3.1"
+
+[build_dependencies.h2]
+package = "h2"
+version = "=0.4.0"
+
+[build_dependencies.h2_0_3_22]
+package = "h2"
+version = "=0.3.22"
+
+[build_dependencies.half]
+package = "half"
+version = "=2.2.1"
+features = ["alloc", "std"]
+
+[build_dependencies.hashbrown]
+package = "hashbrown"
+version = "=0.14.3"
+features = ["ahash", "allocator-api2", "inline-more", "raw"]
+
+[build_dependencies.hashbrown_0_12_3]
+package = "hashbrown"
+version = "=0.12.3"
+features = ["raw"]
+default-features = false
+
+[build_dependencies.hashlink]
+package = "hashlink"
+version = "=0.8.4"
+
+[build_dependencies.heck]
+package = "heck"
+version = "=0.4.1"
+
+[build_dependencies.hmac]
+package = "hmac"
+version = "=0.12.1"
+
+[build_dependencies.html5ever]
+package = "html5ever"
+version = "=0.26.0"
+
+[build_dependencies.http]
+package = "http"
+version = "=1.0.0"
+features = ["std"]
+
+[build_dependencies.http_0_2_11]
+package = "http"
+version = "=0.2.11"
+
+[build_dependencies.http_body]
+package = "http-body"
+version = "=1.0.0"
+
+[build_dependencies.http_body_0_4_6]
+package = "http-body"
+version = "=0.4.6"
+
+[build_dependencies.httparse]
+package = "httparse"
+version = "=1.8.0"
+features = ["std"]
+
+[build_dependencies.httpdate]
+package = "httpdate"
+version = "=1.0.3"
+
+[build_dependencies.humantime]
+package = "humantime"
+version = "=2.1.0"
+
+[build_dependencies.hyper]
+package = "hyper"
+version = "=1.1.0"
+features = ["client", "full", "http1", "http2", "server"]
+
+[build_dependencies.hyper_0_14_28]
+package = "hyper"
+version = "=0.14.28"
+features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"]
+default-features = false
+
+[build_dependencies.hyper_tls]
+package = "hyper-tls"
+version = "=0.5.0"
+
+[build_dependencies.iana_time_zone]
+package = "iana-time-zone"
+version = "=0.1.58"
+features = ["fallback"]
+
+[build_dependencies.idna]
+package = "idna"
+version = "=0.5.0"
+features = ["alloc", "std"]
+
+[build_dependencies.idna_0_2_3]
+package = "idna"
+version = "=0.2.3"
+
+[build_dependencies.idna_0_3_0]
+package = "idna"
+version = "=0.3.0"
+
+[build_dependencies.image]
+package = "image"
+version = "=0.24.7"
+features = ["bmp", "dds", "dxt", "exr", "farbfeld", "gif", "hdr", "ico", "jpeg", "jpeg_rayon", "openexr", "png", "pnm", "qoi", "tga", "tiff", "webp"]
+
+[build_dependencies.indexmap]
+package = "indexmap"
+version = "=2.1.0"
+features = ["std"]
+
+[build_dependencies.indexmap_1_9_3]
+package = "indexmap"
+version = "=1.9.3"
+features = ["std"]
+
+[build_dependencies.iovec]
+package = "iovec"
+version = "=0.1.4"
+
+[build_dependencies.ipnet]
+package = "ipnet"
+version = "=2.9.0"
+features = ["std"]
+
+[build_dependencies.is_terminal]
+package = "is-terminal"
+version = "=0.4.9"
+
+[build_dependencies.itertools]
+package = "itertools"
+version = "=0.12.0"
+features = ["use_alloc", "use_std"]
+
+[build_dependencies.itoa]
+package = "itoa"
+version = "=1.0.10"
+
+[build_dependencies.jpeg_decoder]
+package = "jpeg-decoder"
+version = "=0.3.0"
+features = ["rayon"]
+default-features = false
+
+[build_dependencies.lazy_static]
+package = "lazy_static"
+version = "=1.4.0"
+
+[build_dependencies.lebe]
+package = "lebe"
+version = "=0.5.2"
+
+[build_dependencies.libc]
+package = "libc"
+version = "=0.2.151"
+features = ["extra_traits", "std"]
+
+[build_dependencies.libm]
+package = "libm"
+version = "=0.2.8"
+
+[build_dependencies.libsqlite3_sys]
+package = "libsqlite3-sys"
+version = "=0.27.0"
+features = ["bundled", "bundled_bindings", "cc", "min_sqlite_version_3_14_0", "pkg-config", "unlock_notify", "vcpkg"]
+
+[build_dependencies.linked_hash_map]
+package = "linked-hash-map"
+version = "=0.5.6"
+
+[build_dependencies.linux_raw_sys]
+package = "linux-raw-sys"
+version = "=0.4.12"
+features = ["elf", "errno", "general", "ioctl", "no_std", "std"]
+default-features = false
+
+[build_dependencies.lock_api]
+package = "lock_api"
+version = "=0.4.11"
+features = ["atomic_usize"]
+
+[build_dependencies.log]
+package = "log"
+version = "=0.4.20"
+features = ["serde", "std"]
+
+[build_dependencies.log4rs]
+package = "log4rs"
+version = "=1.2.0"
+features = ["all_components", "ansi_writer", "chrono", "compound_policy", "config_parsing", "console_appender", "console_writer", "delete_roller", "file_appender", "fixed_window_roller", "humantime", "json_encoder", "libc", "log-mdc", "parking_lot", "pattern_encoder", "rolling_file_appender", "serde", "serde-value", "serde_json", "serde_yaml", "simple_writer", "size_trigger", "thread-id", "threshold_filter", "typemap-ors", "winapi", "yaml_format"]
+
+[build_dependencies.log_mdc]
+package = "log-mdc"
+version = "=0.1.0"
+
+[build_dependencies.mac]
+package = "mac"
+version = "=0.1.1"
+
+[build_dependencies.markup5ever]
+package = "markup5ever"
+version = "=0.11.0"
+
+[build_dependencies.markup5ever_rcdom]
+package = "markup5ever_rcdom"
+version = "=0.2.0"
+
+[build_dependencies.matches]
+package = "matches"
+version = "=0.1.10"
+
+[build_dependencies.matrixmultiply]
+package = "matrixmultiply"
+version = "=0.3.8"
+features = ["cgemm", "std"]
+
+[build_dependencies.md5]
+package = "md-5"
+version = "=0.10.6"
+features = ["std"]
+
+[build_dependencies.memchr]
+package = "memchr"
+version = "=2.6.4"
+features = ["alloc", "std"]
+
+[build_dependencies.memmap]
+package = "memmap"
+version = "=0.7.0"
+
+[build_dependencies.memoffset]
+package = "memoffset"
+version = "=0.9.0"
+
+[build_dependencies.mime]
+package = "mime"
+version = "=0.3.17"
+
+[build_dependencies.mime_guess]
+package = "mime_guess"
+version = "=2.0.4"
+default-features = false
+
+[build_dependencies.minimal_lexical]
+package = "minimal-lexical"
+version = "=0.2.1"
+features = ["std"]
+default-features = false
+
+[build_dependencies.miniz_oxide]
+package = "miniz_oxide"
+version = "=0.7.1"
+features = ["simd", "simd-adler32", "with-alloc"]
+
+[build_dependencies.mio]
+package = "mio"
+version = "=0.8.10"
+features = ["log", "net", "os-ext", "os-poll"]
+
+[build_dependencies.nalgebra]
+package = "nalgebra"
+version = "=0.32.3"
+features = ["macros", "matrixmultiply", "nalgebra-macros", "std"]
+
+[build_dependencies.nalgebra_macros]
+package = "nalgebra-macros"
+version = "=0.2.1"
+
+[build_dependencies.native_tls]
+package = "native-tls"
+version = "=0.2.11"
+
+[build_dependencies.ndarray]
+package = "ndarray"
+version = "=0.15.6"
+features = ["std"]
+
+[build_dependencies.nom]
+package = "nom"
+version = "=7.1.3"
+features = ["alloc", "std"]
+
+[build_dependencies.num]
+package = "num"
+version = "=0.4.1"
+features = ["num-bigint", "std"]
+
+[build_dependencies.num_bigint]
+package = "num-bigint"
+version = "=0.4.4"
+features = ["std"]
+default-features = false
+
+[build_dependencies.num_complex]
+package = "num-complex"
+version = "=0.4.4"
+features = ["std"]
+default-features = false
+
+[build_dependencies.num_cpus]
+package = "num_cpus"
+version = "=1.16.0"
+
+[build_dependencies.num_integer]
+package = "num-integer"
+version = "=0.1.45"
+features = ["i128", "std"]
+
+[build_dependencies.num_iter]
+package = "num-iter"
+version = "=0.1.43"
+features = ["i128", "std"]
+default-features = false
+
+[build_dependencies.num_rational]
+package = "num-rational"
+version = "=0.4.1"
+features = ["num-bigint", "num-bigint-std", "std"]
+default-features = false
+
+[build_dependencies.num_traits]
+package = "num-traits"
+version = "=0.2.17"
+features = ["i128", "libm", "std"]
+
+[build_dependencies.object]
+package = "object"
+version = "=0.32.1"
+features = ["archive", "coff", "elf", "macho", "pe", "read_core", "unaligned"]
+default-features = false
+
+[build_dependencies.once_cell]
+package = "once_cell"
+version = "=1.19.0"
+features = ["alloc", "race", "std", "unstable"]
+
+[build_dependencies.openssl]
+package = "openssl"
+version = "=0.10.61"
+
+[build_dependencies.openssl_macros]
+package = "openssl-macros"
+version = "=0.1.1"
+
+[build_dependencies.openssl_probe]
+package = "openssl-probe"
+version = "=0.1.5"
+
+[build_dependencies.openssl_sys]
+package = "openssl-sys"
+version = "=0.9.97"
+
+[build_dependencies.ordered_float]
+package = "ordered-float"
+version = "=2.10.1"
+features = ["std"]
+
+[build_dependencies.parking_lot]
+package = "parking_lot"
+version = "=0.12.1"
+
+[build_dependencies.parking_lot_core]
+package = "parking_lot_core"
+version = "=0.9.9"
+
+[build_dependencies.paste]
+package = "paste"
+version = "=1.0.14"
+
+[build_dependencies.percent_encoding]
+package = "percent-encoding"
+version = "=2.3.1"
+features = ["alloc", "std"]
+
+[build_dependencies.petgraph]
+package = "petgraph"
+version = "=0.6.4"
+features = ["graphmap", "matrix_graph", "stable_graph"]
+
+[build_dependencies.phf]
+package = "phf"
+version = "=0.11.2"
+features = ["macros", "phf_macros", "std"]
+
+[build_dependencies.phf_0_10_1]
+package = "phf"
+version = "=0.10.1"
+features = ["std"]
+
+[build_dependencies.phf_codegen]
+package = "phf_codegen"
+version = "=0.10.0"
+
+[build_dependencies.phf_generator]
+package = "phf_generator"
+version = "=0.11.2"
+
+[build_dependencies.phf_generator_0_10_0]
+package = "phf_generator"
+version = "=0.10.0"
+
+[build_dependencies.phf_macros]
+package = "phf_macros"
+version = "=0.11.2"
+
+[build_dependencies.phf_shared]
+package = "phf_shared"
+version = "=0.11.2"
+features = ["std"]
+default-features = false
+
+[build_dependencies.phf_shared_0_10_0]
+package = "phf_shared"
+version = "=0.10.0"
+features = ["std"]
+
+[build_dependencies.pin_project_lite]
+package = "pin-project-lite"
+version = "=0.2.13"
+
+[build_dependencies.pin_utils]
+package = "pin-utils"
+version = "=0.1.0"
+
+[build_dependencies.pkg_config]
+package = "pkg-config"
+version = "=0.3.28"
+
+[build_dependencies.png]
+package = "png"
+version = "=0.17.10"
+
+[build_dependencies.postgres]
+package = "postgres"
+version = "=0.19.7"
+
+[build_dependencies.postgres_protocol]
+package = "postgres-protocol"
+version = "=0.6.6"
+
+[build_dependencies.postgres_types]
+package = "postgres-types"
+version = "=0.2.6"
+
+[build_dependencies.powerfmt]
+package = "powerfmt"
+version = "=0.2.0"
+default-features = false
+
+[build_dependencies.ppv_lite86]
+package = "ppv-lite86"
+version = "=0.2.17"
+features = ["simd", "std"]
+
+[build_dependencies.precomputed_hash]
+package = "precomputed-hash"
+version = "=0.1.1"
+
+[build_dependencies.proc_macro2]
+package = "proc-macro2"
+version = "=1.0.71"
+features = ["proc-macro", "span-locations"]
+
+[build_dependencies.psl_types]
+package = "psl-types"
+version = "=2.0.11"
+
+[build_dependencies.publicsuffix]
+package = "publicsuffix"
+version = "=2.2.3"
+features = ["idna", "punycode"]
+
+[build_dependencies.qoi]
+package = "qoi"
+version = "=0.4.1"
+features = ["std"]
+
+[build_dependencies.quote]
+package = "quote"
+version = "=1.0.33"
+features = ["proc-macro"]
+
+[build_dependencies.rand]
+package = "rand"
+version = "=0.8.5"
+features = ["alloc", "getrandom", "libc", "rand_chacha", "serde", "serde1", "small_rng", "std", "std_rng"]
+
+[build_dependencies.rand_chacha]
+package = "rand_chacha"
+version = "=0.3.1"
+features = ["std"]
+
+[build_dependencies.rand_core]
+package = "rand_core"
+version = "=0.6.4"
+features = ["alloc", "getrandom", "serde", "serde1", "std"]
+
+[build_dependencies.rand_distr]
+package = "rand_distr"
+version = "=0.4.3"
+features = ["alloc", "std"]
+
+[build_dependencies.rawpointer]
+package = "rawpointer"
+version = "=0.2.1"
+
+[build_dependencies.rayon]
+package = "rayon"
+version = "=1.8.0"
+
+[build_dependencies.rayon_core]
+package = "rayon-core"
+version = "=1.12.0"
+
+[build_dependencies.regex]
+package = "regex"
+version = "=1.10.2"
+features = ["perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
+
+[build_dependencies.regex_automata]
+package = "regex-automata"
+version = "=0.4.3"
+features = ["alloc", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "nfa-pikevm", "nfa-thompson", "perf-inline", "perf-literal", "perf-literal-multisubstring", "perf-literal-substring", "std", "syntax", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment", "unicode-word-boundary"]
+default-features = false
+
+[build_dependencies.regex_syntax]
+package = "regex-syntax"
+version = "=0.8.2"
+features = ["std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
+
+[build_dependencies.reqwest]
+package = "reqwest"
+version = "=0.11.23"
+features = ["__tls", "blocking", "cookie_crate", "cookie_store", "cookies", "default-tls", "hyper-tls", "json", "mime_guess", "multipart", "native-tls-crate", "serde_json", "tokio-native-tls"]
+
+[build_dependencies.ring]
+package = "ring"
+version = "=0.17.7"
+features = ["alloc", "dev_urandom_fallback"]
+
+[build_dependencies.rusqlite]
+package = "rusqlite"
+version = "=0.30.0"
+features = ["array", "backup", "blob", "bundled", "bundled-full", "chrono", "collation", "column_decltype", "csv", "csvtab", "extra_check", "functions", "hooks", "i128_blob", "limits", "load_extension", "modern-full", "modern_sqlite", "serde_json", "series", "time", "trace", "unlock_notify", "url", "uuid", "vtab", "window"]
+
+[build_dependencies.rustc_demangle]
+package = "rustc-demangle"
+version = "=0.1.23"
+
+[build_dependencies.rustc_version]
+package = "rustc_version"
+version = "=0.4.0"
+
+[build_dependencies.rustix]
+package = "rustix"
+version = "=0.38.28"
+features = ["alloc", "fs", "std", "termios", "use-libc-auxv"]
+
+[build_dependencies.ryu]
+package = "ryu"
+version = "=1.0.16"
+
+[build_dependencies.safe_arch]
+package = "safe_arch"
+version = "=0.7.1"
+features = ["bytemuck"]
+
+[build_dependencies.same_file]
+package = "same-file"
+version = "=1.0.6"
+
+[build_dependencies.scopeguard]
+package = "scopeguard"
+version = "=1.2.0"
+features = ["use_std"]
+
+[build_dependencies.select]
+package = "select"
+version = "=0.6.0"
+
+[build_dependencies.semver]
+package = "semver"
+version = "=1.0.20"
+features = ["std"]
+
+[build_dependencies.serde]
+package = "serde"
+version = "=1.0.193"
+features = ["alloc", "derive", "rc", "serde_derive", "std"]
+
+[build_dependencies.serde_derive]
+package = "serde_derive"
+version = "=1.0.193"
+
+[build_dependencies.serde_json]
+package = "serde_json"
+version = "=1.0.108"
+features = ["raw_value", "std"]
+
+[build_dependencies.serde_spanned]
+package = "serde_spanned"
+version = "=0.6.5"
+features = ["serde"]
+
+[build_dependencies.serde_urlencoded]
+package = "serde_urlencoded"
+version = "=0.7.1"
+
+[build_dependencies.serde_value]
+package = "serde-value"
+version = "=0.7.0"
+
+[build_dependencies.serde_yaml]
+package = "serde_yaml"
+version = "=0.8.26"
+
+[build_dependencies.sha1_smol]
+package = "sha1_smol"
+version = "=1.0.0"
+
+[build_dependencies.sha2]
+package = "sha2"
+version = "=0.10.8"
+features = ["std"]
+
+[build_dependencies.signal_hook_registry]
+package = "signal-hook-registry"
+version = "=1.4.1"
+
+[build_dependencies.simba]
+package = "simba"
+version = "=0.8.1"
+features = ["std", "wide"]
+default-features = false
+
+[build_dependencies.simd_adler32]
+package = "simd-adler32"
+version = "=0.3.7"
+features = ["const-generics", "std"]
+
+[build_dependencies.siphasher]
+package = "siphasher"
+version = "=0.3.11"
+features = ["std"]
+
+[build_dependencies.slab]
+package = "slab"
+version = "=0.4.9"
+features = ["std"]
+
+[build_dependencies.smallvec]
+package = "smallvec"
+version = "=1.11.2"
+
+[build_dependencies.smawk]
+package = "smawk"
+version = "=0.3.2"
+
+[build_dependencies.socket2]
+package = "socket2"
+version = "=0.5.5"
+features = ["all"]
+
+[build_dependencies.spin]
+package = "spin"
+version = "=0.9.8"
+features = ["barrier", "lazy", "lock_api", "lock_api_crate", "mutex", "once", "rwlock", "spin_mutex"]
+
+[build_dependencies.string_cache]
+package = "string_cache"
+version = "=0.8.7"
+features = ["serde", "serde_support"]
+
+[build_dependencies.string_cache_codegen]
+package = "string_cache_codegen"
+version = "=0.5.2"
+
+[build_dependencies.stringprep]
+package = "stringprep"
+version = "=0.1.4"
+
+[build_dependencies.strsim]
+package = "strsim"
+version = "=0.10.0"
+
+[build_dependencies.subtle]
+package = "subtle"
+version = "=2.5.0"
+default-features = false
+
+[build_dependencies.syn]
+package = "syn"
+version = "=2.0.42"
+features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"]
+
+[build_dependencies.syn_1_0_109]
+package = "syn"
+version = "=1.0.109"
+features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"]
+
+[build_dependencies.tar]
+package = "tar"
+version = "=0.4.40"
+features = ["xattr"]
+
+[build_dependencies.tempfile]
+package = "tempfile"
+version = "=3.8.1"
+
+[build_dependencies.tendril]
+package = "tendril"
+version = "=0.4.3"
+
+[build_dependencies.termcolor]
+package = "termcolor"
+version = "=1.4.0"
+
+[build_dependencies.terminal_size]
+package = "terminal_size"
+version = "=0.3.0"
+
+[build_dependencies.textwrap]
+package = "textwrap"
+version = "=0.16.0"
+features = ["smawk", "unicode-linebreak", "unicode-width"]
+
+[build_dependencies.thiserror]
+package = "thiserror"
+version = "=1.0.51"
+
+[build_dependencies.thiserror_impl]
+package = "thiserror-impl"
+version = "=1.0.51"
+
+[build_dependencies.thread_id]
+package = "thread-id"
+version = "=4.2.1"
+
+[build_dependencies.thread_local]
+package = "thread_local"
+version = "=1.1.7"
+
+[build_dependencies.threadpool]
+package = "threadpool"
+version = "=1.8.1"
+
+[build_dependencies.tiff]
+package = "tiff"
+version = "=0.9.0"
+
+[build_dependencies.time]
+package = "time"
+version = "=0.3.31"
+features = ["alloc", "formatting", "macros", "parsing", "std"]
+
+[build_dependencies.time_core]
+package = "time-core"
+version = "=0.1.2"
+
+[build_dependencies.time_macros]
+package = "time-macros"
+version = "=0.2.16"
+features = ["formatting", "parsing"]
+
+[build_dependencies.tinyvec]
+package = "tinyvec"
+version = "=1.6.0"
+features = ["alloc", "grab_spare_slice", "rustc_1_40", "rustc_1_55", "serde", "std", "tinyvec_macros"]
+
+[build_dependencies.tinyvec_macros]
+package = "tinyvec_macros"
+version = "=0.1.1"
+
+[build_dependencies.tokio]
+package = "tokio"
+version = "=1.35.1"
+features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "num_cpus", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros", "windows-sys"]
+
+[build_dependencies.tokio_io]
+package = "tokio-io"
+version = "=0.1.13"
+
+[build_dependencies.tokio_macros]
+package = "tokio-macros"
+version = "=2.2.0"
+
+[build_dependencies.tokio_native_tls]
+package = "tokio-native-tls"
+version = "=0.3.1"
+
+[build_dependencies.tokio_postgres]
+package = "tokio-postgres"
+version = "=0.7.10"
+features = ["runtime"]
+
+[build_dependencies.tokio_util]
+package = "tokio-util"
+version = "=0.7.10"
+features = ["codec", "io", "tracing"]
+
+[build_dependencies.toml]
+package = "toml"
+version = "=0.8.8"
+features = ["display", "parse"]
+
+[build_dependencies.toml_datetime]
+package = "toml_datetime"
+version = "=0.6.5"
+features = ["serde"]
+
+[build_dependencies.toml_edit]
+package = "toml_edit"
+version = "=0.21.0"
+features = ["display", "parse", "serde"]
+default-features = false
+
+[build_dependencies.tower_service]
+package = "tower-service"
+version = "=0.3.2"
+
+[build_dependencies.tracing]
+package = "tracing"
+version = "=0.1.40"
+features = ["attributes", "std", "tracing-attributes"]
+
+[build_dependencies.tracing_attributes]
+package = "tracing-attributes"
+version = "=0.1.27"
+
+[build_dependencies.tracing_core]
+package = "tracing-core"
+version = "=0.1.32"
+features = ["once_cell", "std", "valuable"]
+
+[build_dependencies.try_lock]
+package = "try-lock"
+version = "=0.2.5"
+
+[build_dependencies.typemap_ors]
+package = "typemap-ors"
+version = "=1.0.0"
+
+[build_dependencies.typenum]
+package = "typenum"
+version = "=1.17.0"
+features = ["const-generics", "i128"]
+
+[build_dependencies.unicase]
+package = "unicase"
+version = "=2.7.0"
+
+[build_dependencies.unicode_bidi]
+package = "unicode-bidi"
+version = "=0.3.14"
+features = ["hardcoded-data", "std"]
+
+[build_dependencies.unicode_ident]
+package = "unicode-ident"
+version = "=1.0.12"
+
+[build_dependencies.unicode_linebreak]
+package = "unicode-linebreak"
+version = "=0.1.5"
+
+[build_dependencies.unicode_normalization]
+package = "unicode-normalization"
+version = "=0.1.22"
+features = ["std"]
+
+[build_dependencies.unicode_segmentation]
+package = "unicode-segmentation"
+version = "=1.10.1"
+
+[build_dependencies.unicode_width]
+package = "unicode-width"
+version = "=0.1.11"
+
+[build_dependencies.unicode_xid]
+package = "unicode-xid"
+version = "=0.2.4"
+
+[build_dependencies.unsafe_any_ors]
+package = "unsafe-any-ors"
+version = "=1.0.0"
+
+[build_dependencies.untrusted]
+package = "untrusted"
+version = "=0.9.0"
+
+[build_dependencies.url]
+package = "url"
+version = "=2.5.0"
+features = ["serde"]
+
+[build_dependencies.utf8]
+package = "utf-8"
+version = "=0.7.6"
+
+[build_dependencies.utf8parse]
+package = "utf8parse"
+version = "=0.2.1"
+
+[build_dependencies.uuid]
+package = "uuid"
+version = "=1.6.1"
+features = ["atomic", "getrandom", "md-5", "md5", "rng", "serde", "sha1", "sha1_smol", "std", "v1", "v3", "v4", "v5", "v6", "v7", "v8"]
+
+[build_dependencies.vcpkg]
+package = "vcpkg"
+version = "=0.2.15"
+
+[build_dependencies.version_check]
+package = "version_check"
+version = "=0.9.4"
+
+[build_dependencies.walkdir]
+package = "walkdir"
+version = "=2.4.0"
+
+[build_dependencies.want]
+package = "want"
+version = "=0.3.1"
+
+[build_dependencies.weezl]
+package = "weezl"
+version = "=0.1.7"
+features = ["alloc", "std"]
+
+[build_dependencies.whoami]
+package = "whoami"
+version = "=1.4.1"
+features = ["wasm-bindgen", "web", "web-sys"]
+
+[build_dependencies.wide]
+package = "wide"
+version = "=0.7.13"
+features = ["std"]
+default-features = false
+
+[build_dependencies.winnow]
+package = "winnow"
+version = "=0.5.30"
+features = ["alloc", "std"]
+
+[build_dependencies.xattr]
+package = "xattr"
+version = "=1.1.3"
+features = ["unsupported"]
+
+[build_dependencies.xml5ever]
+package = "xml5ever"
+version = "=0.17.0"
+
+[build_dependencies.yaml_rust]
+package = "yaml-rust"
+version = "=0.4.5"
+
+[build_dependencies.zerocopy]
+package = "zerocopy"
+version = "=0.7.32"
+features = ["__internal_use_only_features_that_work_on_stable", "alloc", "derive", "simd", "zerocopy-derive"]
+default-features = false
+
+[build_dependencies.zerocopy_derive]
+package = "zerocopy-derive"
+version = "=0.7.32"
+
+[build_dependencies.zeroize]
+package = "zeroize"
+version = "=1.7.0"
+default-features = false
+
+[build_dependencies.zune_inflate]
+package = "zune-inflate"
+version = "=0.2.54"
+features = ["simd-adler32", "zlib"]
+default-features = false

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -10,7 +10,7 @@ ENV CARGO_TERM_COLOR="never"
 ENV TERM="dumb"
 
 COPY Cargo.lock Cargo.toml crate-information.json crate-modifications.toml /app/
-RUN touch benches/bench.rs && touch src/lib.rs && rustup install nightly && cargo install cargo-criterion && cargo vendor && mkdir -p /app/.cargo/
+RUN mkdir -p /app/benches && mkdir -p /app/src && touch /app/benches/bench.rs && touch /app/src/lib.rs && rustup install nightly && cargo install cargo-criterion && cargo vendor && mkdir -p /app/.cargo/
 COPY extra-cargo.toml /app/.cargo/config.toml
 
 CMD ["echo ERROR"]

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -10,7 +10,7 @@ ENV CARGO_TERM_COLOR="never"
 ENV TERM="dumb"
 
 COPY Cargo.lock Cargo.toml crate-information.json crate-modifications.toml /app/
-RUN rustup install nightly && cargo install cargo-criterion && cargo vendor && mkdir -p /app/.cargo/
+RUN touch benches/bench.rs && touch src/lib.rs && rustup install nightly && cargo install cargo-criterion && cargo vendor && mkdir -p /app/.cargo/
 COPY extra-cargo.toml /app/.cargo/config.toml
 
 CMD ["echo ERROR"]

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,12 +1,16 @@
 FROM rust:latest
-RUN rustup install nightly
+VOLUME /app/src
+VOLUME /app/benches
+VOLUME /app/inputs
+VOLUME /app/target
+WORKDIR /app
 # RUN rustup default nightly
-# We need this to get JSON output from cargo criterion
-RUN cargo install cargo-criterion
 ENV RUSTFLAGS="-C target-cpu=native"
 ENV CARGO_TERM_COLOR="never"
 ENV TERM="dumb"
-VOLUME /app
-WORKDIR /app
+
+COPY Cargo.lock Cargo.toml crate-information.json crate-modifications.toml /app/
+RUN rustup install nightly && cargo install cargo-criterion && cargo vendor && mkdir -p /app/.cargo/
+COPY extra-cargo.toml /app/.cargo/config.toml
 
 CMD ["echo ERROR"]

--- a/runner/crate-information.json
+++ b/runner/crate-information.json
@@ -25,6 +25,11 @@
     "id": "allocator_api2"
   },
   {
+    "name": "anes",
+    "version": "0.1.6",
+    "id": "anes"
+  },
+  {
     "name": "ansi_term",
     "version": "0.12.1",
     "id": "ansi_term"
@@ -63,6 +68,21 @@
     "name": "arc-swap",
     "version": "1.6.0",
     "id": "arc_swap"
+  },
+  {
+    "name": "arrayvec",
+    "version": "0.7.4",
+    "id": "arrayvec"
+  },
+  {
+    "name": "ascii",
+    "version": "1.1.0",
+    "id": "ascii"
+  },
+  {
+    "name": "async-recursion",
+    "version": "1.0.5",
+    "id": "async_recursion"
   },
   {
     "name": "async-trait",
@@ -120,9 +140,19 @@
     "id": "bitflags_1_3_2"
   },
   {
+    "name": "bitvec",
+    "version": "1.0.1",
+    "id": "bitvec"
+  },
+  {
     "name": "block-buffer",
     "version": "0.10.4",
     "id": "block_buffer"
+  },
+  {
+    "name": "btoi",
+    "version": "0.4.3",
+    "id": "btoi"
   },
   {
     "name": "bytemuck",
@@ -150,6 +180,11 @@
     "id": "bytes_0_4_12"
   },
   {
+    "name": "cast",
+    "version": "0.3.0",
+    "id": "cast"
+  },
+  {
     "name": "cc",
     "version": "1.0.83",
     "id": "cc"
@@ -163,6 +198,21 @@
     "name": "chrono",
     "version": "0.4.31",
     "id": "chrono"
+  },
+  {
+    "name": "ciborium",
+    "version": "0.2.1",
+    "id": "ciborium"
+  },
+  {
+    "name": "ciborium-io",
+    "version": "0.2.1",
+    "id": "ciborium_io"
+  },
+  {
+    "name": "ciborium-ll",
+    "version": "0.2.1",
+    "id": "ciborium_ll"
   },
   {
     "name": "clap",
@@ -210,6 +260,11 @@
     "id": "cookie_store"
   },
   {
+    "name": "cpp_demangle",
+    "version": "0.4.3",
+    "id": "cpp_demangle"
+  },
+  {
     "name": "cpufeatures",
     "version": "0.2.11",
     "id": "cpufeatures"
@@ -218,6 +273,16 @@
     "name": "crc32fast",
     "version": "1.3.2",
     "id": "crc32fast"
+  },
+  {
+    "name": "criterion",
+    "version": "0.5.1",
+    "id": "criterion"
+  },
+  {
+    "name": "criterion-plot",
+    "version": "0.5.0",
+    "id": "criterion_plot"
   },
   {
     "name": "crossbeam",
@@ -265,6 +330,11 @@
     "id": "csv_core"
   },
   {
+    "name": "dashmap",
+    "version": "5.5.3",
+    "id": "dashmap"
+  },
+  {
     "name": "data-encoding",
     "version": "2.5.0",
     "id": "data_encoding"
@@ -273,6 +343,11 @@
     "name": "new_debug_unreachable",
     "version": "1.0.4",
     "id": "debug_unreachable"
+  },
+  {
+    "name": "debugid",
+    "version": "0.8.0",
+    "id": "debugid"
   },
   {
     "name": "deranged",
@@ -365,6 +440,11 @@
     "id": "filetime"
   },
   {
+    "name": "findshlibs",
+    "version": "0.10.2",
+    "id": "findshlibs"
+  },
+  {
     "name": "finl_unicode",
     "version": "1.2.0",
     "id": "finl_unicode"
@@ -403,6 +483,11 @@
     "name": "form_urlencoded",
     "version": "1.2.1",
     "id": "form_urlencoded"
+  },
+  {
+    "name": "funty",
+    "version": "2.0.0",
+    "id": "funty"
   },
   {
     "name": "futf",
@@ -503,6 +588,11 @@
     "name": "half",
     "version": "2.2.1",
     "id": "half"
+  },
+  {
+    "name": "half",
+    "version": "1.8.2",
+    "id": "half_1_8_2"
   },
   {
     "name": "hashbrown",
@@ -640,6 +730,11 @@
     "id": "itertools"
   },
   {
+    "name": "itertools",
+    "version": "0.10.5",
+    "id": "itertools_0_10_5"
+  },
+  {
     "name": "itoa",
     "version": "1.0.10",
     "id": "itoa"
@@ -745,6 +840,11 @@
     "id": "memmap"
   },
   {
+    "name": "memmap2",
+    "version": "0.9.3",
+    "id": "memmap2"
+  },
+  {
     "name": "memoffset",
     "version": "0.9.0",
     "id": "memoffset"
@@ -793,6 +893,11 @@
     "name": "ndarray",
     "version": "0.15.6",
     "id": "ndarray"
+  },
+  {
+    "name": "nix",
+    "version": "0.26.4",
+    "id": "nix"
   },
   {
     "name": "nom",
@@ -850,6 +955,11 @@
     "id": "once_cell"
   },
   {
+    "name": "oorandom",
+    "version": "11.1.3",
+    "id": "oorandom"
+  },
+  {
     "name": "openssl",
     "version": "0.10.61",
     "id": "openssl"
@@ -883,6 +993,11 @@
     "name": "parking_lot_core",
     "version": "0.9.9",
     "id": "parking_lot_core"
+  },
+  {
+    "name": "parse",
+    "version": "0.1.2",
+    "id": "parse"
   },
   {
     "name": "paste",
@@ -955,6 +1070,21 @@
     "id": "pkg_config"
   },
   {
+    "name": "plotters",
+    "version": "0.3.5",
+    "id": "plotters"
+  },
+  {
+    "name": "plotters-backend",
+    "version": "0.3.5",
+    "id": "plotters_backend"
+  },
+  {
+    "name": "plotters-svg",
+    "version": "0.3.5",
+    "id": "plotters_svg"
+  },
+  {
     "name": "png",
     "version": "0.17.10",
     "id": "png"
@@ -978,6 +1108,11 @@
     "name": "powerfmt",
     "version": "0.2.0",
     "id": "powerfmt"
+  },
+  {
+    "name": "pprof",
+    "version": "0.13.0",
+    "id": "pprof"
   },
   {
     "name": "ppv-lite86",
@@ -1013,6 +1148,11 @@
     "name": "quote",
     "version": "1.0.33",
     "id": "quote"
+  },
+  {
+    "name": "radium",
+    "version": "0.7.0",
+    "id": "radium"
   },
   {
     "name": "rand",
@@ -1215,6 +1355,11 @@
     "id": "spin"
   },
   {
+    "name": "stable_deref_trait",
+    "version": "1.2.0",
+    "id": "stable_deref_trait"
+  },
+  {
     "name": "string_cache",
     "version": "0.8.7",
     "id": "string_cache"
@@ -1240,6 +1385,16 @@
     "id": "subtle"
   },
   {
+    "name": "symbolic-common",
+    "version": "12.8.0",
+    "id": "symbolic_common"
+  },
+  {
+    "name": "symbolic-demangle",
+    "version": "12.8.0",
+    "id": "symbolic_demangle"
+  },
+  {
     "name": "syn",
     "version": "2.0.42",
     "id": "syn"
@@ -1248,6 +1403,11 @@
     "name": "syn",
     "version": "1.0.109",
     "id": "syn_1_0_109"
+  },
+  {
+    "name": "tap",
+    "version": "1.0.1",
+    "id": "tap"
   },
   {
     "name": "tar",
@@ -1323,6 +1483,11 @@
     "name": "time-macros",
     "version": "0.2.16",
     "id": "time_macros"
+  },
+  {
+    "name": "tinytemplate",
+    "version": "1.2.1",
+    "id": "tinytemplate"
   },
   {
     "name": "tinyvec",
@@ -1523,6 +1688,11 @@
     "name": "winnow",
     "version": "0.5.30",
     "id": "winnow"
+  },
+  {
+    "name": "wyz",
+    "version": "0.5.1",
+    "id": "wyz"
   },
   {
     "name": "xattr",

--- a/runner/crate-information.json
+++ b/runner/crate-information.json
@@ -1685,6 +1685,16 @@
     "id": "wide"
   },
   {
+    "name": "windows-targets",
+    "version": "0.52.0",
+    "id": "windows_targets"
+  },
+  {
+    "name": "windows_x86_64_gnu",
+    "version": "0.52.0",
+    "id": "windows_x86_64_gnu"
+  },
+  {
     "name": "winnow",
     "version": "0.5.30",
     "id": "winnow"

--- a/runner/crate-information.json
+++ b/runner/crate-information.json
@@ -1,0 +1,1562 @@
+[
+  {
+    "name": "addr2line",
+    "version": "0.21.0",
+    "id": "addr2line"
+  },
+  {
+    "name": "adler",
+    "version": "1.0.2",
+    "id": "adler"
+  },
+  {
+    "name": "ahash",
+    "version": "0.8.6",
+    "id": "ahash"
+  },
+  {
+    "name": "aho-corasick",
+    "version": "1.1.2",
+    "id": "aho_corasick"
+  },
+  {
+    "name": "allocator-api2",
+    "version": "0.2.16",
+    "id": "allocator_api2"
+  },
+  {
+    "name": "ansi_term",
+    "version": "0.12.1",
+    "id": "ansi_term"
+  },
+  {
+    "name": "anstream",
+    "version": "0.6.5",
+    "id": "anstream"
+  },
+  {
+    "name": "anstyle",
+    "version": "1.0.4",
+    "id": "anstyle"
+  },
+  {
+    "name": "anstyle-parse",
+    "version": "0.2.3",
+    "id": "anstyle_parse"
+  },
+  {
+    "name": "anstyle-query",
+    "version": "1.0.2",
+    "id": "anstyle_query"
+  },
+  {
+    "name": "anyhow",
+    "version": "1.0.76",
+    "id": "anyhow"
+  },
+  {
+    "name": "approx",
+    "version": "0.5.1",
+    "id": "approx"
+  },
+  {
+    "name": "arc-swap",
+    "version": "1.6.0",
+    "id": "arc_swap"
+  },
+  {
+    "name": "async-trait",
+    "version": "0.1.75",
+    "id": "async_trait"
+  },
+  {
+    "name": "atomic",
+    "version": "0.5.3",
+    "id": "atomic"
+  },
+  {
+    "name": "atty",
+    "version": "0.2.14",
+    "id": "atty"
+  },
+  {
+    "name": "autocfg",
+    "version": "1.1.0",
+    "id": "autocfg"
+  },
+  {
+    "name": "backtrace",
+    "version": "0.3.69",
+    "id": "backtrace"
+  },
+  {
+    "name": "base64",
+    "version": "0.21.5",
+    "id": "base64"
+  },
+  {
+    "name": "bit_field",
+    "version": "0.10.2",
+    "id": "bit_field"
+  },
+  {
+    "name": "bit-set",
+    "version": "0.5.3",
+    "id": "bit_set"
+  },
+  {
+    "name": "bit-vec",
+    "version": "0.6.3",
+    "id": "bit_vec"
+  },
+  {
+    "name": "bitflags",
+    "version": "2.4.1",
+    "id": "bitflags"
+  },
+  {
+    "name": "bitflags",
+    "version": "1.3.2",
+    "id": "bitflags_1_3_2"
+  },
+  {
+    "name": "block-buffer",
+    "version": "0.10.4",
+    "id": "block_buffer"
+  },
+  {
+    "name": "bytemuck",
+    "version": "1.14.0",
+    "id": "bytemuck"
+  },
+  {
+    "name": "bytemuck_derive",
+    "version": "1.5.0",
+    "id": "bytemuck_derive"
+  },
+  {
+    "name": "byteorder",
+    "version": "1.5.0",
+    "id": "byteorder"
+  },
+  {
+    "name": "bytes",
+    "version": "1.5.0",
+    "id": "bytes"
+  },
+  {
+    "name": "bytes",
+    "version": "0.4.12",
+    "id": "bytes_0_4_12"
+  },
+  {
+    "name": "cc",
+    "version": "1.0.83",
+    "id": "cc"
+  },
+  {
+    "name": "cfg-if",
+    "version": "1.0.0",
+    "id": "cfg_if"
+  },
+  {
+    "name": "chrono",
+    "version": "0.4.31",
+    "id": "chrono"
+  },
+  {
+    "name": "clap",
+    "version": "4.4.11",
+    "id": "clap"
+  },
+  {
+    "name": "clap_builder",
+    "version": "4.4.11",
+    "id": "clap_builder"
+  },
+  {
+    "name": "clap_derive",
+    "version": "4.4.7",
+    "id": "clap_derive"
+  },
+  {
+    "name": "clap_lex",
+    "version": "0.6.0",
+    "id": "clap_lex"
+  },
+  {
+    "name": "color_quant",
+    "version": "1.1.0",
+    "id": "color_quant"
+  },
+  {
+    "name": "colorchoice",
+    "version": "1.0.0",
+    "id": "colorchoice"
+  },
+  {
+    "name": "const-default",
+    "version": "1.0.0",
+    "id": "const_default"
+  },
+  {
+    "name": "cookie",
+    "version": "0.16.2",
+    "id": "cookie"
+  },
+  {
+    "name": "cookie_store",
+    "version": "0.16.2",
+    "id": "cookie_store"
+  },
+  {
+    "name": "cpufeatures",
+    "version": "0.2.11",
+    "id": "cpufeatures"
+  },
+  {
+    "name": "crc32fast",
+    "version": "1.3.2",
+    "id": "crc32fast"
+  },
+  {
+    "name": "crossbeam",
+    "version": "0.8.2",
+    "id": "crossbeam"
+  },
+  {
+    "name": "crossbeam-channel",
+    "version": "0.5.9",
+    "id": "crossbeam_channel"
+  },
+  {
+    "name": "crossbeam-deque",
+    "version": "0.8.4",
+    "id": "crossbeam_deque"
+  },
+  {
+    "name": "crossbeam-epoch",
+    "version": "0.9.16",
+    "id": "crossbeam_epoch"
+  },
+  {
+    "name": "crossbeam-queue",
+    "version": "0.3.9",
+    "id": "crossbeam_queue"
+  },
+  {
+    "name": "crossbeam-utils",
+    "version": "0.8.17",
+    "id": "crossbeam_utils"
+  },
+  {
+    "name": "crypto-common",
+    "version": "0.1.6",
+    "id": "crypto_common"
+  },
+  {
+    "name": "csv",
+    "version": "1.3.0",
+    "id": "csv"
+  },
+  {
+    "name": "csv-core",
+    "version": "0.1.11",
+    "id": "csv_core"
+  },
+  {
+    "name": "data-encoding",
+    "version": "2.5.0",
+    "id": "data_encoding"
+  },
+  {
+    "name": "new_debug_unreachable",
+    "version": "1.0.4",
+    "id": "debug_unreachable"
+  },
+  {
+    "name": "deranged",
+    "version": "0.3.10",
+    "id": "deranged"
+  },
+  {
+    "name": "derivative",
+    "version": "2.2.0",
+    "id": "derivative"
+  },
+  {
+    "name": "destructure_traitobject",
+    "version": "0.2.0",
+    "id": "destructure_traitobject"
+  },
+  {
+    "name": "digest",
+    "version": "0.10.7",
+    "id": "digest"
+  },
+  {
+    "name": "either",
+    "version": "1.9.0",
+    "id": "either"
+  },
+  {
+    "name": "encoding_rs",
+    "version": "0.8.33",
+    "id": "encoding_rs"
+  },
+  {
+    "name": "env_logger",
+    "version": "0.10.1",
+    "id": "env_logger"
+  },
+  {
+    "name": "equivalent",
+    "version": "1.0.1",
+    "id": "equivalent"
+  },
+  {
+    "name": "errno",
+    "version": "0.3.8",
+    "id": "errno"
+  },
+  {
+    "name": "error-chain",
+    "version": "0.12.4",
+    "id": "error_chain"
+  },
+  {
+    "name": "exr",
+    "version": "1.71.0",
+    "id": "exr"
+  },
+  {
+    "name": "fallible-iterator",
+    "version": "0.3.0",
+    "id": "fallible_iterator"
+  },
+  {
+    "name": "fallible-iterator",
+    "version": "0.2.0",
+    "id": "fallible_iterator_0_2_0"
+  },
+  {
+    "name": "fallible-streaming-iterator",
+    "version": "0.1.9",
+    "id": "fallible_streaming_iterator"
+  },
+  {
+    "name": "faster-hex",
+    "version": "0.8.1",
+    "id": "faster_hex"
+  },
+  {
+    "name": "fastrand",
+    "version": "2.0.1",
+    "id": "fastrand"
+  },
+  {
+    "name": "fdeflate",
+    "version": "0.3.1",
+    "id": "fdeflate"
+  },
+  {
+    "name": "filetime",
+    "version": "0.2.23",
+    "id": "filetime"
+  },
+  {
+    "name": "finl_unicode",
+    "version": "1.2.0",
+    "id": "finl_unicode"
+  },
+  {
+    "name": "fixedbitset",
+    "version": "0.4.2",
+    "id": "fixedbitset"
+  },
+  {
+    "name": "flate2",
+    "version": "1.0.28",
+    "id": "flate2"
+  },
+  {
+    "name": "flume",
+    "version": "0.11.0",
+    "id": "flume"
+  },
+  {
+    "name": "fnv",
+    "version": "1.0.7",
+    "id": "fnv"
+  },
+  {
+    "name": "foreign-types",
+    "version": "0.3.2",
+    "id": "foreign_types"
+  },
+  {
+    "name": "foreign-types-shared",
+    "version": "0.1.1",
+    "id": "foreign_types_shared"
+  },
+  {
+    "name": "form_urlencoded",
+    "version": "1.2.1",
+    "id": "form_urlencoded"
+  },
+  {
+    "name": "futf",
+    "version": "0.1.5",
+    "id": "futf"
+  },
+  {
+    "name": "futures",
+    "version": "0.3.29",
+    "id": "futures"
+  },
+  {
+    "name": "futures",
+    "version": "0.1.31",
+    "id": "futures_0_1_31"
+  },
+  {
+    "name": "futures-channel",
+    "version": "0.3.29",
+    "id": "futures_channel"
+  },
+  {
+    "name": "futures-core",
+    "version": "0.3.29",
+    "id": "futures_core"
+  },
+  {
+    "name": "futures-executor",
+    "version": "0.3.29",
+    "id": "futures_executor"
+  },
+  {
+    "name": "futures-io",
+    "version": "0.3.29",
+    "id": "futures_io"
+  },
+  {
+    "name": "futures-macro",
+    "version": "0.3.29",
+    "id": "futures_macro"
+  },
+  {
+    "name": "futures-sink",
+    "version": "0.3.29",
+    "id": "futures_sink"
+  },
+  {
+    "name": "futures-task",
+    "version": "0.3.29",
+    "id": "futures_task"
+  },
+  {
+    "name": "futures-util",
+    "version": "0.3.29",
+    "id": "futures_util"
+  },
+  {
+    "name": "generic-array",
+    "version": "1.0.0",
+    "id": "generic_array"
+  },
+  {
+    "name": "generic-array",
+    "version": "0.14.7",
+    "id": "generic_array_0_14_7"
+  },
+  {
+    "name": "getrandom",
+    "version": "0.2.11",
+    "id": "getrandom"
+  },
+  {
+    "name": "gif",
+    "version": "0.12.0",
+    "id": "gif"
+  },
+  {
+    "name": "gimli",
+    "version": "0.28.1",
+    "id": "gimli"
+  },
+  {
+    "name": "glob",
+    "version": "0.3.1",
+    "id": "glob"
+  },
+  {
+    "name": "h2",
+    "version": "0.4.0",
+    "id": "h2"
+  },
+  {
+    "name": "h2",
+    "version": "0.3.22",
+    "id": "h2_0_3_22"
+  },
+  {
+    "name": "half",
+    "version": "2.2.1",
+    "id": "half"
+  },
+  {
+    "name": "hashbrown",
+    "version": "0.14.3",
+    "id": "hashbrown"
+  },
+  {
+    "name": "hashbrown",
+    "version": "0.12.3",
+    "id": "hashbrown_0_12_3"
+  },
+  {
+    "name": "hashlink",
+    "version": "0.8.4",
+    "id": "hashlink"
+  },
+  {
+    "name": "heck",
+    "version": "0.4.1",
+    "id": "heck"
+  },
+  {
+    "name": "hmac",
+    "version": "0.12.1",
+    "id": "hmac"
+  },
+  {
+    "name": "html5ever",
+    "version": "0.26.0",
+    "id": "html5ever"
+  },
+  {
+    "name": "http",
+    "version": "1.0.0",
+    "id": "http"
+  },
+  {
+    "name": "http",
+    "version": "0.2.11",
+    "id": "http_0_2_11"
+  },
+  {
+    "name": "http-body",
+    "version": "1.0.0",
+    "id": "http_body"
+  },
+  {
+    "name": "http-body",
+    "version": "0.4.6",
+    "id": "http_body_0_4_6"
+  },
+  {
+    "name": "httparse",
+    "version": "1.8.0",
+    "id": "httparse"
+  },
+  {
+    "name": "httpdate",
+    "version": "1.0.3",
+    "id": "httpdate"
+  },
+  {
+    "name": "humantime",
+    "version": "2.1.0",
+    "id": "humantime"
+  },
+  {
+    "name": "hyper",
+    "version": "1.1.0",
+    "id": "hyper"
+  },
+  {
+    "name": "hyper",
+    "version": "0.14.28",
+    "id": "hyper_0_14_28"
+  },
+  {
+    "name": "hyper-tls",
+    "version": "0.5.0",
+    "id": "hyper_tls"
+  },
+  {
+    "name": "iana-time-zone",
+    "version": "0.1.58",
+    "id": "iana_time_zone"
+  },
+  {
+    "name": "idna",
+    "version": "0.5.0",
+    "id": "idna"
+  },
+  {
+    "name": "idna",
+    "version": "0.2.3",
+    "id": "idna_0_2_3"
+  },
+  {
+    "name": "idna",
+    "version": "0.3.0",
+    "id": "idna_0_3_0"
+  },
+  {
+    "name": "image",
+    "version": "0.24.7",
+    "id": "image"
+  },
+  {
+    "name": "indexmap",
+    "version": "2.1.0",
+    "id": "indexmap"
+  },
+  {
+    "name": "indexmap",
+    "version": "1.9.3",
+    "id": "indexmap_1_9_3"
+  },
+  {
+    "name": "iovec",
+    "version": "0.1.4",
+    "id": "iovec"
+  },
+  {
+    "name": "ipnet",
+    "version": "2.9.0",
+    "id": "ipnet"
+  },
+  {
+    "name": "is-terminal",
+    "version": "0.4.9",
+    "id": "is_terminal"
+  },
+  {
+    "name": "itertools",
+    "version": "0.12.0",
+    "id": "itertools"
+  },
+  {
+    "name": "itoa",
+    "version": "1.0.10",
+    "id": "itoa"
+  },
+  {
+    "name": "jpeg-decoder",
+    "version": "0.3.0",
+    "id": "jpeg_decoder"
+  },
+  {
+    "name": "lazy_static",
+    "version": "1.4.0",
+    "id": "lazy_static"
+  },
+  {
+    "name": "lebe",
+    "version": "0.5.2",
+    "id": "lebe"
+  },
+  {
+    "name": "libc",
+    "version": "0.2.151",
+    "id": "libc"
+  },
+  {
+    "name": "libm",
+    "version": "0.2.8",
+    "id": "libm"
+  },
+  {
+    "name": "libsqlite3-sys",
+    "version": "0.27.0",
+    "id": "libsqlite3_sys"
+  },
+  {
+    "name": "linked-hash-map",
+    "version": "0.5.6",
+    "id": "linked_hash_map"
+  },
+  {
+    "name": "linux-raw-sys",
+    "version": "0.4.12",
+    "id": "linux_raw_sys"
+  },
+  {
+    "name": "lock_api",
+    "version": "0.4.11",
+    "id": "lock_api"
+  },
+  {
+    "name": "log",
+    "version": "0.4.20",
+    "id": "log"
+  },
+  {
+    "name": "log4rs",
+    "version": "1.2.0",
+    "id": "log4rs"
+  },
+  {
+    "name": "log-mdc",
+    "version": "0.1.0",
+    "id": "log_mdc"
+  },
+  {
+    "name": "mac",
+    "version": "0.1.1",
+    "id": "mac"
+  },
+  {
+    "name": "markup5ever",
+    "version": "0.11.0",
+    "id": "markup5ever"
+  },
+  {
+    "name": "markup5ever_rcdom",
+    "version": "0.2.0",
+    "id": "markup5ever_rcdom"
+  },
+  {
+    "name": "matches",
+    "version": "0.1.10",
+    "id": "matches"
+  },
+  {
+    "name": "matrixmultiply",
+    "version": "0.3.8",
+    "id": "matrixmultiply"
+  },
+  {
+    "name": "md-5",
+    "version": "0.10.6",
+    "id": "md5"
+  },
+  {
+    "name": "memchr",
+    "version": "2.6.4",
+    "id": "memchr"
+  },
+  {
+    "name": "memmap",
+    "version": "0.7.0",
+    "id": "memmap"
+  },
+  {
+    "name": "memoffset",
+    "version": "0.9.0",
+    "id": "memoffset"
+  },
+  {
+    "name": "mime",
+    "version": "0.3.17",
+    "id": "mime"
+  },
+  {
+    "name": "mime_guess",
+    "version": "2.0.4",
+    "id": "mime_guess"
+  },
+  {
+    "name": "minimal-lexical",
+    "version": "0.2.1",
+    "id": "minimal_lexical"
+  },
+  {
+    "name": "miniz_oxide",
+    "version": "0.7.1",
+    "id": "miniz_oxide"
+  },
+  {
+    "name": "mio",
+    "version": "0.8.10",
+    "id": "mio"
+  },
+  {
+    "name": "nalgebra",
+    "version": "0.32.3",
+    "id": "nalgebra"
+  },
+  {
+    "name": "nalgebra-macros",
+    "version": "0.2.1",
+    "id": "nalgebra_macros"
+  },
+  {
+    "name": "native-tls",
+    "version": "0.2.11",
+    "id": "native_tls"
+  },
+  {
+    "name": "ndarray",
+    "version": "0.15.6",
+    "id": "ndarray"
+  },
+  {
+    "name": "nom",
+    "version": "7.1.3",
+    "id": "nom"
+  },
+  {
+    "name": "num",
+    "version": "0.4.1",
+    "id": "num"
+  },
+  {
+    "name": "num-bigint",
+    "version": "0.4.4",
+    "id": "num_bigint"
+  },
+  {
+    "name": "num-complex",
+    "version": "0.4.4",
+    "id": "num_complex"
+  },
+  {
+    "name": "num_cpus",
+    "version": "1.16.0",
+    "id": "num_cpus"
+  },
+  {
+    "name": "num-integer",
+    "version": "0.1.45",
+    "id": "num_integer"
+  },
+  {
+    "name": "num-iter",
+    "version": "0.1.43",
+    "id": "num_iter"
+  },
+  {
+    "name": "num-rational",
+    "version": "0.4.1",
+    "id": "num_rational"
+  },
+  {
+    "name": "num-traits",
+    "version": "0.2.17",
+    "id": "num_traits"
+  },
+  {
+    "name": "object",
+    "version": "0.32.1",
+    "id": "object"
+  },
+  {
+    "name": "once_cell",
+    "version": "1.19.0",
+    "id": "once_cell"
+  },
+  {
+    "name": "openssl",
+    "version": "0.10.61",
+    "id": "openssl"
+  },
+  {
+    "name": "openssl-macros",
+    "version": "0.1.1",
+    "id": "openssl_macros"
+  },
+  {
+    "name": "openssl-probe",
+    "version": "0.1.5",
+    "id": "openssl_probe"
+  },
+  {
+    "name": "openssl-sys",
+    "version": "0.9.97",
+    "id": "openssl_sys"
+  },
+  {
+    "name": "ordered-float",
+    "version": "2.10.1",
+    "id": "ordered_float"
+  },
+  {
+    "name": "parking_lot",
+    "version": "0.12.1",
+    "id": "parking_lot"
+  },
+  {
+    "name": "parking_lot_core",
+    "version": "0.9.9",
+    "id": "parking_lot_core"
+  },
+  {
+    "name": "paste",
+    "version": "1.0.14",
+    "id": "paste"
+  },
+  {
+    "name": "percent-encoding",
+    "version": "2.3.1",
+    "id": "percent_encoding"
+  },
+  {
+    "name": "petgraph",
+    "version": "0.6.4",
+    "id": "petgraph"
+  },
+  {
+    "name": "phf",
+    "version": "0.11.2",
+    "id": "phf"
+  },
+  {
+    "name": "phf",
+    "version": "0.10.1",
+    "id": "phf_0_10_1"
+  },
+  {
+    "name": "phf_codegen",
+    "version": "0.10.0",
+    "id": "phf_codegen"
+  },
+  {
+    "name": "phf_generator",
+    "version": "0.11.2",
+    "id": "phf_generator"
+  },
+  {
+    "name": "phf_generator",
+    "version": "0.10.0",
+    "id": "phf_generator_0_10_0"
+  },
+  {
+    "name": "phf_macros",
+    "version": "0.11.2",
+    "id": "phf_macros"
+  },
+  {
+    "name": "phf_shared",
+    "version": "0.11.2",
+    "id": "phf_shared"
+  },
+  {
+    "name": "phf_shared",
+    "version": "0.10.0",
+    "id": "phf_shared_0_10_0"
+  },
+  {
+    "name": "pin-project-lite",
+    "version": "0.2.13",
+    "id": "pin_project_lite"
+  },
+  {
+    "name": "pin-utils",
+    "version": "0.1.0",
+    "id": "pin_utils"
+  },
+  {
+    "name": "pkg-config",
+    "version": "0.3.28",
+    "id": "pkg_config"
+  },
+  {
+    "name": "png",
+    "version": "0.17.10",
+    "id": "png"
+  },
+  {
+    "name": "postgres",
+    "version": "0.19.7",
+    "id": "postgres"
+  },
+  {
+    "name": "postgres-protocol",
+    "version": "0.6.6",
+    "id": "postgres_protocol"
+  },
+  {
+    "name": "postgres-types",
+    "version": "0.2.6",
+    "id": "postgres_types"
+  },
+  {
+    "name": "powerfmt",
+    "version": "0.2.0",
+    "id": "powerfmt"
+  },
+  {
+    "name": "ppv-lite86",
+    "version": "0.2.17",
+    "id": "ppv_lite86"
+  },
+  {
+    "name": "precomputed-hash",
+    "version": "0.1.1",
+    "id": "precomputed_hash"
+  },
+  {
+    "name": "proc-macro2",
+    "version": "1.0.71",
+    "id": "proc_macro2"
+  },
+  {
+    "name": "psl-types",
+    "version": "2.0.11",
+    "id": "psl_types"
+  },
+  {
+    "name": "publicsuffix",
+    "version": "2.2.3",
+    "id": "publicsuffix"
+  },
+  {
+    "name": "qoi",
+    "version": "0.4.1",
+    "id": "qoi"
+  },
+  {
+    "name": "quote",
+    "version": "1.0.33",
+    "id": "quote"
+  },
+  {
+    "name": "rand",
+    "version": "0.8.5",
+    "id": "rand"
+  },
+  {
+    "name": "rand_chacha",
+    "version": "0.3.1",
+    "id": "rand_chacha"
+  },
+  {
+    "name": "rand_core",
+    "version": "0.6.4",
+    "id": "rand_core"
+  },
+  {
+    "name": "rand_distr",
+    "version": "0.4.3",
+    "id": "rand_distr"
+  },
+  {
+    "name": "rawpointer",
+    "version": "0.2.1",
+    "id": "rawpointer"
+  },
+  {
+    "name": "rayon",
+    "version": "1.8.0",
+    "id": "rayon"
+  },
+  {
+    "name": "rayon-core",
+    "version": "1.12.0",
+    "id": "rayon_core"
+  },
+  {
+    "name": "regex",
+    "version": "1.10.2",
+    "id": "regex"
+  },
+  {
+    "name": "regex-automata",
+    "version": "0.4.3",
+    "id": "regex_automata"
+  },
+  {
+    "name": "regex-syntax",
+    "version": "0.8.2",
+    "id": "regex_syntax"
+  },
+  {
+    "name": "reqwest",
+    "version": "0.11.23",
+    "id": "reqwest"
+  },
+  {
+    "name": "ring",
+    "version": "0.17.7",
+    "id": "ring"
+  },
+  {
+    "name": "rusqlite",
+    "version": "0.30.0",
+    "id": "rusqlite"
+  },
+  {
+    "name": "rustc-demangle",
+    "version": "0.1.23",
+    "id": "rustc_demangle"
+  },
+  {
+    "name": "rustc_version",
+    "version": "0.4.0",
+    "id": "rustc_version"
+  },
+  {
+    "name": "rustix",
+    "version": "0.38.28",
+    "id": "rustix"
+  },
+  {
+    "name": "ryu",
+    "version": "1.0.16",
+    "id": "ryu"
+  },
+  {
+    "name": "safe_arch",
+    "version": "0.7.1",
+    "id": "safe_arch"
+  },
+  {
+    "name": "same-file",
+    "version": "1.0.6",
+    "id": "same_file"
+  },
+  {
+    "name": "scopeguard",
+    "version": "1.2.0",
+    "id": "scopeguard"
+  },
+  {
+    "name": "select",
+    "version": "0.6.0",
+    "id": "select"
+  },
+  {
+    "name": "semver",
+    "version": "1.0.20",
+    "id": "semver"
+  },
+  {
+    "name": "serde",
+    "version": "1.0.193",
+    "id": "serde"
+  },
+  {
+    "name": "serde_derive",
+    "version": "1.0.193",
+    "id": "serde_derive"
+  },
+  {
+    "name": "serde_json",
+    "version": "1.0.108",
+    "id": "serde_json"
+  },
+  {
+    "name": "serde_spanned",
+    "version": "0.6.5",
+    "id": "serde_spanned"
+  },
+  {
+    "name": "serde_urlencoded",
+    "version": "0.7.1",
+    "id": "serde_urlencoded"
+  },
+  {
+    "name": "serde-value",
+    "version": "0.7.0",
+    "id": "serde_value"
+  },
+  {
+    "name": "serde_yaml",
+    "version": "0.8.26",
+    "id": "serde_yaml"
+  },
+  {
+    "name": "sha1_smol",
+    "version": "1.0.0",
+    "id": "sha1_smol"
+  },
+  {
+    "name": "sha2",
+    "version": "0.10.8",
+    "id": "sha2"
+  },
+  {
+    "name": "signal-hook-registry",
+    "version": "1.4.1",
+    "id": "signal_hook_registry"
+  },
+  {
+    "name": "simba",
+    "version": "0.8.1",
+    "id": "simba"
+  },
+  {
+    "name": "simd-adler32",
+    "version": "0.3.7",
+    "id": "simd_adler32"
+  },
+  {
+    "name": "siphasher",
+    "version": "0.3.11",
+    "id": "siphasher"
+  },
+  {
+    "name": "slab",
+    "version": "0.4.9",
+    "id": "slab"
+  },
+  {
+    "name": "smallvec",
+    "version": "1.11.2",
+    "id": "smallvec"
+  },
+  {
+    "name": "smawk",
+    "version": "0.3.2",
+    "id": "smawk"
+  },
+  {
+    "name": "socket2",
+    "version": "0.5.5",
+    "id": "socket2"
+  },
+  {
+    "name": "spin",
+    "version": "0.9.8",
+    "id": "spin"
+  },
+  {
+    "name": "string_cache",
+    "version": "0.8.7",
+    "id": "string_cache"
+  },
+  {
+    "name": "string_cache_codegen",
+    "version": "0.5.2",
+    "id": "string_cache_codegen"
+  },
+  {
+    "name": "stringprep",
+    "version": "0.1.4",
+    "id": "stringprep"
+  },
+  {
+    "name": "strsim",
+    "version": "0.10.0",
+    "id": "strsim"
+  },
+  {
+    "name": "subtle",
+    "version": "2.5.0",
+    "id": "subtle"
+  },
+  {
+    "name": "syn",
+    "version": "2.0.42",
+    "id": "syn"
+  },
+  {
+    "name": "syn",
+    "version": "1.0.109",
+    "id": "syn_1_0_109"
+  },
+  {
+    "name": "tar",
+    "version": "0.4.40",
+    "id": "tar"
+  },
+  {
+    "name": "tempfile",
+    "version": "3.8.1",
+    "id": "tempfile"
+  },
+  {
+    "name": "tendril",
+    "version": "0.4.3",
+    "id": "tendril"
+  },
+  {
+    "name": "termcolor",
+    "version": "1.4.0",
+    "id": "termcolor"
+  },
+  {
+    "name": "terminal_size",
+    "version": "0.3.0",
+    "id": "terminal_size"
+  },
+  {
+    "name": "textwrap",
+    "version": "0.16.0",
+    "id": "textwrap"
+  },
+  {
+    "name": "thiserror",
+    "version": "1.0.51",
+    "id": "thiserror"
+  },
+  {
+    "name": "thiserror-impl",
+    "version": "1.0.51",
+    "id": "thiserror_impl"
+  },
+  {
+    "name": "thread-id",
+    "version": "4.2.1",
+    "id": "thread_id"
+  },
+  {
+    "name": "thread_local",
+    "version": "1.1.7",
+    "id": "thread_local"
+  },
+  {
+    "name": "threadpool",
+    "version": "1.8.1",
+    "id": "threadpool"
+  },
+  {
+    "name": "tiff",
+    "version": "0.9.0",
+    "id": "tiff"
+  },
+  {
+    "name": "time",
+    "version": "0.3.31",
+    "id": "time"
+  },
+  {
+    "name": "time-core",
+    "version": "0.1.2",
+    "id": "time_core"
+  },
+  {
+    "name": "time-macros",
+    "version": "0.2.16",
+    "id": "time_macros"
+  },
+  {
+    "name": "tinyvec",
+    "version": "1.6.0",
+    "id": "tinyvec"
+  },
+  {
+    "name": "tinyvec_macros",
+    "version": "0.1.1",
+    "id": "tinyvec_macros"
+  },
+  {
+    "name": "tokio",
+    "version": "1.35.1",
+    "id": "tokio"
+  },
+  {
+    "name": "tokio-io",
+    "version": "0.1.13",
+    "id": "tokio_io"
+  },
+  {
+    "name": "tokio-macros",
+    "version": "2.2.0",
+    "id": "tokio_macros"
+  },
+  {
+    "name": "tokio-native-tls",
+    "version": "0.3.1",
+    "id": "tokio_native_tls"
+  },
+  {
+    "name": "tokio-postgres",
+    "version": "0.7.10",
+    "id": "tokio_postgres"
+  },
+  {
+    "name": "tokio-util",
+    "version": "0.7.10",
+    "id": "tokio_util"
+  },
+  {
+    "name": "toml",
+    "version": "0.8.8",
+    "id": "toml"
+  },
+  {
+    "name": "toml_datetime",
+    "version": "0.6.5",
+    "id": "toml_datetime"
+  },
+  {
+    "name": "toml_edit",
+    "version": "0.21.0",
+    "id": "toml_edit"
+  },
+  {
+    "name": "tower-service",
+    "version": "0.3.2",
+    "id": "tower_service"
+  },
+  {
+    "name": "tracing",
+    "version": "0.1.40",
+    "id": "tracing"
+  },
+  {
+    "name": "tracing-attributes",
+    "version": "0.1.27",
+    "id": "tracing_attributes"
+  },
+  {
+    "name": "tracing-core",
+    "version": "0.1.32",
+    "id": "tracing_core"
+  },
+  {
+    "name": "try-lock",
+    "version": "0.2.5",
+    "id": "try_lock"
+  },
+  {
+    "name": "typemap-ors",
+    "version": "1.0.0",
+    "id": "typemap_ors"
+  },
+  {
+    "name": "typenum",
+    "version": "1.17.0",
+    "id": "typenum"
+  },
+  {
+    "name": "unicase",
+    "version": "2.7.0",
+    "id": "unicase"
+  },
+  {
+    "name": "unicode-bidi",
+    "version": "0.3.14",
+    "id": "unicode_bidi"
+  },
+  {
+    "name": "unicode-ident",
+    "version": "1.0.12",
+    "id": "unicode_ident"
+  },
+  {
+    "name": "unicode-linebreak",
+    "version": "0.1.5",
+    "id": "unicode_linebreak"
+  },
+  {
+    "name": "unicode-normalization",
+    "version": "0.1.22",
+    "id": "unicode_normalization"
+  },
+  {
+    "name": "unicode-segmentation",
+    "version": "1.10.1",
+    "id": "unicode_segmentation"
+  },
+  {
+    "name": "unicode-width",
+    "version": "0.1.11",
+    "id": "unicode_width"
+  },
+  {
+    "name": "unicode-xid",
+    "version": "0.2.4",
+    "id": "unicode_xid"
+  },
+  {
+    "name": "unsafe-any-ors",
+    "version": "1.0.0",
+    "id": "unsafe_any_ors"
+  },
+  {
+    "name": "untrusted",
+    "version": "0.9.0",
+    "id": "untrusted"
+  },
+  {
+    "name": "url",
+    "version": "2.5.0",
+    "id": "url"
+  },
+  {
+    "name": "utf-8",
+    "version": "0.7.6",
+    "id": "utf8"
+  },
+  {
+    "name": "utf8parse",
+    "version": "0.2.1",
+    "id": "utf8parse"
+  },
+  {
+    "name": "uuid",
+    "version": "1.6.1",
+    "id": "uuid"
+  },
+  {
+    "name": "vcpkg",
+    "version": "0.2.15",
+    "id": "vcpkg"
+  },
+  {
+    "name": "version_check",
+    "version": "0.9.4",
+    "id": "version_check"
+  },
+  {
+    "name": "walkdir",
+    "version": "2.4.0",
+    "id": "walkdir"
+  },
+  {
+    "name": "want",
+    "version": "0.3.1",
+    "id": "want"
+  },
+  {
+    "name": "weezl",
+    "version": "0.1.7",
+    "id": "weezl"
+  },
+  {
+    "name": "whoami",
+    "version": "1.4.1",
+    "id": "whoami"
+  },
+  {
+    "name": "wide",
+    "version": "0.7.13",
+    "id": "wide"
+  },
+  {
+    "name": "winnow",
+    "version": "0.5.30",
+    "id": "winnow"
+  },
+  {
+    "name": "xattr",
+    "version": "1.1.3",
+    "id": "xattr"
+  },
+  {
+    "name": "xml5ever",
+    "version": "0.17.0",
+    "id": "xml5ever"
+  },
+  {
+    "name": "yaml-rust",
+    "version": "0.4.5",
+    "id": "yaml_rust"
+  },
+  {
+    "name": "zerocopy",
+    "version": "0.7.32",
+    "id": "zerocopy"
+  },
+  {
+    "name": "zerocopy-derive",
+    "version": "0.7.32",
+    "id": "zerocopy_derive"
+  },
+  {
+    "name": "zeroize",
+    "version": "1.7.0",
+    "id": "zeroize"
+  },
+  {
+    "name": "zune-inflate",
+    "version": "0.2.54",
+    "id": "zune_inflate"
+  }
+]

--- a/runner/crate-modifications.toml
+++ b/runner/crate-modifications.toml
@@ -15,7 +15,6 @@ additions = [
     "memchr",
     "arrayvec",
     "smallvec",
-    "rustc",
     "bitvec",
     "dashmap",
     "btoi",

--- a/runner/crate-modifications.toml
+++ b/runner/crate-modifications.toml
@@ -1,0 +1,24 @@
+exclusions = []
+
+additions = [
+    # Crates that the compiler recommends
+    # rg 'https://crates.io/crates/[a-z_-]+' --glob '*.stderr' --only-matching --no-line-number --no-filename | sort | uniq | cut -d '/' -f 5
+    "async-trait",
+    "async-recursion",
+    "criterion",
+    "pprof",
+    "bytemuck",
+    "itertools",
+    "rayon",
+    "regex",
+    "parse",
+    "memchr",
+    "arrayvec",
+    "smallvec",
+    "rustc",
+    "bitvec",
+    "dashmap",
+    "btoi",
+    "nom",
+    "ascii",
+]

--- a/runner/crate-modifications.toml
+++ b/runner/crate-modifications.toml
@@ -20,4 +20,5 @@ additions = [
     "btoi",
     "nom",
     "ascii",
+    "windows-targets",
 ]

--- a/runner/extra-cargo.toml
+++ b/runner/extra-cargo.toml
@@ -1,0 +1,5 @@
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"


### PR DESCRIPTION
While I'd love it if `cargo vet` had most of the crates we'd want reviewed, that doesn't appear to be the case. So, instead, I stole [rust-playground's downloader](https://crates.io/crates/rust-playground-top-crates), ran it, and vendored the crates.

The vendored part is important so we can do offline builds. Offline builds, in turn, are important if we want to switch from two `docker run`s to run/exec/exec. More realistically, for release, we'll probably just keep the two `docker run` invocations, but tell docker to disconnect the network for both build & run.

Resolves #9 