### PR TITLE
feat: Automatically check user answers

### DIFF
--- a/database.py
+++ b/database.py
@@ -86,6 +86,11 @@ class Database:
 
         self._cursor.executemany(query, db_results)
 
+    def set_verified_answer(self, _year: int, day: int, part: int, session_label: str, answer: str):
+        """Set the verified answer for a specific problem, part, and input."""
+        query = """INSERT INTO solutions(key, day, part, answer2) VALUES (?, ?, ?, ?)"""
+        self._cursor.execute(query, (session_label, day, part, answer))
+
     def best_times(self, _year: int, day: int, part: int, /) -> Iterator[tuple[int, float]]:
         """Gets the best times for a given day/part, returning a user_id+timestamp in sorted by lowest time first order"""
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -775,4 +775,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ef3ecff3e0b2d26a93d53b1be2d3e4e2bf08da799beb8e4f8f6221be3845a5b1"
+content-hash = "bc73e3d23a15c742685b1099bd98166b6d4f0dedd4b92b6c8ffc2325e4353d92"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dynaconf = "^3.2.4"
 tzdata = "^2023.3"
 # this is used in fetch.py
 requests = "^2.31.0"
+aiohttp = "^3.9.1"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.1.8"


### PR DESCRIPTION
Any time a user submits code, check the answers against the AOC website if we don't already have them.

I do expect to have to rework this, but an attempt was made to make a reasonably robust solution, and also to do some clean-up before publishing.

Resolves #41 .