### PR TITLE
feat: Don't cycle the year until it's December

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import discord
 from config import settings
 
@@ -69,4 +70,6 @@ Be kind and do not abuse :)""",
 
 LEADERBOARD_FOOTER = "Need help? DM me /help or /info to get started."
 
-MAX_DAY = 25
+# Type checking needs to be told this is a literal (and the exact value), else
+# it just assumes an int.
+MAX_DAY: Literal[25] = 25

--- a/lib.py
+++ b/lib.py
@@ -336,9 +336,9 @@ def year() -> Year:
     # changing the season until 12am Dec 1.
     stamp = datetime.now(tz=ZoneInfo("America/New_York"))
     if stamp.month == 12:
-        return cast(Year, stamp.year)
+        return Year(stamp.year)
     else:
-        return cast(Year, stamp.year - 1)
+        return Year(stamp.year - 1)
 
 
 def today() -> AdventDay:
@@ -352,6 +352,4 @@ def today() -> AdventDay:
         assert day > 0
         return cast(AdventDay, day)
     else:
-        # `constants` should be in the right type already, but that'd require
-        # importing `database` in `constants`, which is backwards.
-        return cast(AdventDay, constants.MAX_DAY)
+        return constants.MAX_DAY

--- a/lib.py
+++ b/lib.py
@@ -17,6 +17,7 @@ import docker
 from discord.ext import commands
 
 from config import settings
+import constants
 from database import AdventDay, AdventPart, AocInput, Database, Picoseconds, SessionLabel, Year
 
 doc = docker.from_env()
@@ -329,14 +330,23 @@ def get_best_times(
     return (times1, times2)
 
 
-def year() -> Year:
+def year() -> int:
     """Return the current year, as AOC code should understand it."""
+    # Our day-change happens at the same time as AOC. So, there's no point in
+    # changing the season until 12am Dec 1.
     stamp = datetime.now(tz=ZoneInfo("America/New_York"))
-    return Year(stamp.year)
+    if stamp.month == 12:
+        return stamp.year
+    else:
+        return stamp.year - 1
 
 
-def today() -> AdventDay:
+def today() -> int:
     """Return the current day, as AOC code should understand it."""
+    # Our day-change happens at the same time as AOC. So, there's no point in
+    # changing the season until 12am Dec 1.
     stamp = datetime.now(tz=ZoneInfo("America/New_York"))
-    # SAFETY: day is always greater than 0, and we cap at 25
-    return cast(AdventDay, min(stamp.day, 25))
+    if stamp.month == 12:
+        return min(stamp.day, constants.MAX_DAY)
+    else:
+        return constants.MAX_DAY

--- a/lib.py
+++ b/lib.py
@@ -330,23 +330,28 @@ def get_best_times(
     return (times1, times2)
 
 
-def year() -> int:
+def year() -> Year:
     """Return the current year, as AOC code should understand it."""
     # Our day-change happens at the same time as AOC. So, there's no point in
     # changing the season until 12am Dec 1.
     stamp = datetime.now(tz=ZoneInfo("America/New_York"))
     if stamp.month == 12:
-        return stamp.year
+        return cast(Year, stamp.year)
     else:
-        return stamp.year - 1
+        return cast(Year, stamp.year - 1)
 
 
-def today() -> int:
+def today() -> AdventDay:
     """Return the current day, as AOC code should understand it."""
     # Our day-change happens at the same time as AOC. So, there's no point in
     # changing the season until 12am Dec 1.
     stamp = datetime.now(tz=ZoneInfo("America/New_York"))
     if stamp.month == 12:
-        return min(stamp.day, constants.MAX_DAY)
+        day = min(stamp.day, constants.MAX_DAY)
+        # Satisfy the type-checker
+        assert day > 0
+        return cast(AdventDay, day)
     else:
-        return constants.MAX_DAY
+        # `constants` should be in the right type already, but that'd require
+        # importing `database` in `constants`, which is backwards.
+        return cast(AdventDay, constants.MAX_DAY)


### PR DESCRIPTION
Scraping `today()`/`year()` from a closed PR, so I went ahead and did it.