### PR TITLE
feat: Encode bench format in docker image via tags & label

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,11 @@ jobs:
     - uses: actions/checkout@v3
     - id: dategen
       shell: bash
-      run: echo "docker-version=$(date +%s)" >> $GITHUB_OUTPUT
+      # First command grabs a date stamp
+      # Second grabs a line like `bench_format=4` from the Dockerfile
+      run: |
+        echo "docker-version=$(date +%s)" >> $GITHUB_OUTPUT
+        grep -F bench_format ./runner/Dockerfile | cut -d ' ' -f 2 | tr -d '"' >> $GITHUB_OUTPUT
     - name: Build & Publish the runner image
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:
@@ -27,5 +31,6 @@ jobs:
         registry: ghcr.io
         default_branch: main
         workdir: runner
-        tags: "latest,${{ steps.dategen.outputs.docker-version }}"
+        # Tags: latest, 4, 4.1703023947
+        tags: "latest,${{ steps.dategen.outputs.bench_format }},${{ steps.dategen.outputs.bench_format }}.${{ steps.dategen.outputs.docker-version }}"
         no_push: ${{ github.event_name == 'pull_request' }}

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -4,7 +4,11 @@ VOLUME /app/benches
 VOLUME /app/inputs
 VOLUME /app/target
 WORKDIR /app
-# RUN rustup default nightly
+
+# There's a github action that looks for this line specifically to set versions in the tags
+# (since we can't use docker itself nor client libraries to fetch remote tags filtered by label)
+LABEL bench_format="1"
+
 ENV RUSTFLAGS="-C target-cpu=native"
 ENV CARGO_TERM_COLOR="never"
 ENV TERM="dumb"


### PR DESCRIPTION
We need some way to encode the bench format a container is for in order to populate a table in the DB. Hard-coding the table is a kinda crappy idea since the benching container is built twice a day.

Using a label is the natural way of handling this problem. Unfortunately, CLI tools cannot query a repository for the latest image tag with a given label. So, in order to implement the rest of the code, we're best off putting the bench version in a tag (for now). Rather than choosing one and gambling we won't need to change our mind later, I went ahead and implemented both approaches.