### PR TITLE
[feat] Reduce docker container version count

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,11 @@ on:
     branches: [ "main" ]
   pull_request: {}
   schedule:
-    - cron:  '27 4,17 * * *'
+    - cron:  '27 4,17 1-26 12 *'
+    - cron:  '27 13 27-31 12 *'
+    - cron:  '27 4,17 29,30 11 *'
+    - cron:  '27 13 1-28 11 *'
+    - cron:  '27 13 */7 1-10 *'
 
 permissions:
   packages: write


### PR DESCRIPTION
This alters the container build schedule so that we build less often. We still get a new build with each PR event and every push to main, so this shouldn't impact developer workflow at all, but we don't need 2 builds a day in March.