### PR TITLE
feat: Update container versions in the background

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,6 +13,7 @@ import lib
 from config import settings
 from database import AdventDay, AdventPart, Database, Year
 from error_handler import ErrorHandlerCog
+from runner import bg_update
 
 logger = logging.getLogger(__name__)
 
@@ -148,16 +149,11 @@ async def prefix(dbot: commands.Bot, message: discord.Message) -> list[str]:
     ]
 
 
-async def periodic_check() -> None:
-    # TODO: insert docker container version checking
-    pass
-
-
 async def periodic_check_caller() -> None:
     while True:
         try:
             logger.info("calling periodic check function")
-            await periodic_check()
+            await bg_update()
         except Exception:
             logger.exception("Unknown issue in periodic checking function.")
 

--- a/constants.py
+++ b/constants.py
@@ -2,6 +2,8 @@ from typing import Literal
 import discord
 from config import settings
 
+SUPPORTED_BENCH_FORMAT: int = 1
+
 HELP_REPLY = discord.Embed(
     title="Ferris Elf help page",
     color=0xE84611,

--- a/database.py
+++ b/database.py
@@ -286,7 +286,7 @@ class Database:
 
         # unnamed fields are filled with default types
         rowid = self._cursor.execute(
-            "INSERT INTO submissions (user, year, day_part, code, bencher_version, benchmark_format) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO submissions (user, year, day_part, code, bencher_version, benchmark_format) VALUES (?, ?, ?, ?, ?, ?)",
             (
                 str(author_id),
                 year,

--- a/database.py
+++ b/database.py
@@ -567,10 +567,7 @@ class Database:
         """
         query = "SELECT container_version FROM container_versions"
         res = self._cursor.execute(query).fetchall()
-        if res is None or len(res) == 0:
-            return set(versions)
-        present_versions = set(map(lambda x: x[0], res))
-        return versions.difference(present_versions)
+        return versions.difference({x[0] for x in res})
 
     def insert_container_version(
         self, rustc_ver: str, container_version: str, bench_format: int, bench_dir: bytes, /

--- a/database.py
+++ b/database.py
@@ -561,17 +561,16 @@ class Database:
 
             self.refresh_user_best_runs(year, day, part, user)
 
-    def pick_new_container_versions(self, versions: list[str]) -> set[str]:
+    def pick_new_container_versions(self, versions: set[str]) -> set[str]:
         """
         Given a list of container versions, return those not in the DB already.
         """
         query = "SELECT container_version FROM container_versions"
-        given_versions = set(versions)
         res = self._cursor.execute(query).fetchall()
         if res is None or len(res) == 0:
             return set(versions)
         present_versions = set(map(lambda x: x[0], res))
-        return given_versions.difference(present_versions)
+        return versions.difference(present_versions)
 
     def insert_container_version(
         self, rustc_ver: str, container_version: str, bench_format: int, bench_dir: bytes, /

--- a/database.py
+++ b/database.py
@@ -561,6 +561,18 @@ class Database:
 
             self.refresh_user_best_runs(year, day, part, user)
 
+    def pick_new_container_versions(self, versions: list[str]) -> set[str]:
+        """
+        Given a list of container versions, return those not in the DB already.
+        """
+        query = "SELECT container_version FROM container_versions"
+        given_versions = set(versions)
+        res = self._cursor.execute(query).fetchall()
+        if res is None or len(res) == 0:
+            return set(versions)
+        present_versions = set(map(lambda x: x[0], res))
+        return given_versions.difference(present_versions)
+
     def insert_container_version(
         self, rustc_ver: str, container_version: str, bench_format: int, bench_dir: bytes, /
     ) -> ContainerVersionId:

--- a/lib.py
+++ b/lib.py
@@ -1,5 +1,3 @@
-import asyncio
-import functools
 import json
 import logging
 import os
@@ -16,7 +14,6 @@ import docker
 import discord
 from discord.ext import commands
 
-from config import settings
 import constants
 from database import AdventDay, AdventPart, AocInput, Database, Picoseconds, SessionLabel, Year
 from runner import run_cmd

--- a/lib.py
+++ b/lib.py
@@ -14,16 +14,12 @@ import docker
 import discord
 from discord.ext import commands
 
+from config import settings
 import constants
 from database import AdventDay, AdventPart, AocInput, Database, Picoseconds, SessionLabel, Year
 from runner import run_cmd
 
 logger = logging.getLogger(__name__)
-
-
-def todo() -> NoReturn:
-    # TODO(ultrabear): remove this
-    raise NotImplementedError("we have TODO at home (not implemented yet)")
 
 
 async def benchmark(
@@ -38,9 +34,15 @@ async def benchmark(
 
     try:
         results = []
+
+        with Database() as db:
+            (version_id, container_tag) = db.newest_container_version(
+                constants.SUPPORTED_BENCH_FORMAT
+            )
+
         with tempfile.TemporaryDirectory(suffix=f"-ferris-elf-{op_id}") as tmpdir:
             populate_tmp_dir(tmpdir, code)
-            if not await build_code(op_name, op_id, tmpdir):
+            if not await build_code(container_tag, op_name, op_id, tmpdir):
                 # This reply is not good UX, but it's better than silence.
                 await ctx.reply("Build failed.")
                 return
@@ -51,15 +53,23 @@ async def benchmark(
                 for in_file, contents in db.get_inputs(year, day).items():
                     logger.info("Processing file: %s", in_file)
                     load_input(tmpdir, contents)
-                    result_lst = await run_code(op_name, op_id, tmpdir, in_file)
+                    result_lst = await run_code(container_tag, op_name, op_id, tmpdir, in_file)
                     result = process_run_result(in_file, answers_map, result_lst)
                     if result is not None:
                         results.append(result)
 
-                db.save_results(op_id, year, day, part, code, todo(), todo(), results)
+                db.save_results(
+                    op_id,
+                    year,
+                    day,
+                    part,
+                    code,
+                    version_id,
+                    constants.SUPPORTED_BENCH_FORMAT,
+                    results,
+                )
 
-        # TODO: remove the type ignore when we remove the todo() calls above
-        verified_results = [r for r in results if r.verified]  # type: ignore[unreachable]
+        verified_results = [r for r in results if r.verified]
         if len(verified_results) > 0:
             median = stats.mean([r.median for r in verified_results])
             average = stats.mean([r.average for r in verified_results])
@@ -106,15 +116,21 @@ def populate_tmp_dir(tmp_dir: str, solution_code: bytes) -> None:
     logger.debug("Contents of tmp dir: %s", os.listdir(tmp_dir))
 
 
-async def build_code(author_name: str, author_id: int, tmp_dir: str) -> bool:
+async def build_code(
+    container_version: str, author_name: str, author_id: int, tmp_dir: str
+) -> bool:
     """
     Designed to be used with a basic rust container. Run the container
     with `cargo build` to build the code. Code is mounted in as a volume,
     so that binaries are saved between build/run.
     """
     logger.info("Running container to build code for %s", author_id)
+    image = settings.docker.container_ref
+    if ":" not in image:
+        image = image + ":" + container_version
     try:
         out = await run_cmd(
+            image,
             "timeout --kill-after=5s 90s cargo build --release",
             {},
             vols={
@@ -157,7 +173,7 @@ def load_input(tmp_dir: str, input_data: AocInput) -> None:
 
 
 async def run_code(
-    author_name: str, author_id: int, tmp_dir: str, in_file: SessionLabel, /
+    container_version: str, author_name: str, author_id: int, tmp_dir: str, in_file: SessionLabel, /
 ) -> Optional[list[dict[str, Any]]]:
     """
     Designed to be used with a basic rust container. Given the code already
@@ -165,8 +181,12 @@ async def run_code(
     """
     in_file_name = os.path.join("/app", "inputs", in_file)
     logger.info("Running container to run code for %s", author_id)
+    image = settings.docker.container_ref
+    if ":" not in image:
+        image = image + ":" + container_version
     try:
         out = await run_cmd(
+            image,
             "timeout --kill-after=15s 120s cargo criterion --message-format=json",
             env={
                 "FERRIS_ELF_INPUT_FILE_NAME": in_file_name,

--- a/lib.py
+++ b/lib.py
@@ -7,7 +7,7 @@ import statistics as stats
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, NoReturn, Optional, cast, Self
+from typing import Any, Optional, cast, Self
 from zoneinfo import ZoneInfo
 
 import docker

--- a/lib.py
+++ b/lib.py
@@ -115,10 +115,10 @@ async def build_code(author_name: str, author_id: int, tmp_dir: str) -> bool:
             "timeout --kill-after=5s 30s cargo build",
             {},
             vols={
-                    os.path.join(tmp_dir, "src"): {"bind": "/app/src", "mode": "rw"},
-                    os.path.join(tmp_dir, "benches"): {"bind": "/app/benches", "mode": "rw"},
-                    os.path.join(tmp_dir, "target"): {"bind": "/app/target", "mode": "rw"},
-                },
+                os.path.join(tmp_dir, "src"): {"bind": "/app/src", "mode": "rw"},
+                os.path.join(tmp_dir, "benches"): {"bind": "/app/benches", "mode": "rw"},
+                os.path.join(tmp_dir, "target"): {"bind": "/app/target", "mode": "rw"},
+            },
         )
         logger.debug("Build container output: %s", out)
         return True
@@ -166,14 +166,14 @@ async def run_code(
         out = await run_cmd(
             "timeout --kill-after=15s 120s cargo criterion --message-format=json",
             env={
-                    "FERRIS_ELF_INPUT_FILE_NAME": in_file_name,
-                },
+                "FERRIS_ELF_INPUT_FILE_NAME": in_file_name,
+            },
             vols={
-                    os.path.join(tmp_dir, "src"): {"bind": "/app/src", "mode": "rw"},
-                    os.path.join(tmp_dir, "benches"): {"bind": "/app/benches", "mode": "rw"},
-                    os.path.join(tmp_dir, "inputs"): {"bind": "/app/inputs", "mode": "rw"},
-                    os.path.join(tmp_dir, "target"): {"bind": "/app/target", "mode": "rw"},
-                }
+                os.path.join(tmp_dir, "src"): {"bind": "/app/src", "mode": "rw"},
+                os.path.join(tmp_dir, "benches"): {"bind": "/app/benches", "mode": "rw"},
+                os.path.join(tmp_dir, "inputs"): {"bind": "/app/inputs", "mode": "rw"},
+                os.path.join(tmp_dir, "target"): {"bind": "/app/target", "mode": "rw"},
+            },
         )
         logger.debug("Run container output (type: %s):\n%s", type(out), out)
         results = list[dict[str, Any]]()

--- a/poetry.lock
+++ b/poetry.lock
@@ -775,4 +775,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ef3ecff3e0b2d26a93d53b1be2d3e4e2bf08da799beb8e4f8f6221be3845a5b1"
+content-hash = "bc73e3d23a15c742685b1099bd98166b6d4f0dedd4b92b6c8ffc2325e4353d92"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dynaconf = "^3.2.4"
 tzdata = "^2023.3"
 # this is used in fetch.py
 requests = "^2.31.0"
+aiohttp = "^3.9.1"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.1.8"

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,47 @@
+import logging
+import functools
+import asyncio
+
+import docker
+
+from config import settings
+
+doc = docker.from_env()
+
+logger = logging.getLogger(__name__)
+
+async def run_cmd(cmd: str, env: dict[str, str], vols: dict[str, dict[str, str]]) -> str:
+    """
+    Thin wrapper to simplify the Docker interface & provide secure defaults.
+    """
+    loop = asyncio.get_event_loop()
+    raw_out = await loop.run_in_executor(
+        None,
+        functools.partial(
+            doc.containers.run,
+            settings.docker.container_ref,
+            cmd,
+            environment=env,
+            remove=True,
+            stdout=True,
+            stderr=True,
+            mem_limit="8g",
+            network_mode="none",
+            volumes=vols,
+        ),
+    )
+    out: str = raw_out.decode("utf-8")
+    return out
+
+
+def get_remote_tags(image_ref: str):
+    """Use the OCI Distribution API to get a list of tags for an image."""
+    raise NotImplementedError()
+
+def get_remote_manifest(image_ref: str, tag: str):
+    """Retrieve the manifest for a specific tag of an image."""
+    raise NotImplementedError()
+
+def get_labels(image_manifest: str):
+    """Given a manifest, extract the labels from it."""
+    raise NotImplementedError

--- a/runner.py
+++ b/runner.py
@@ -1,14 +1,20 @@
+import asyncio
+from collections import namedtuple
 import logging
 import functools
-import asyncio
+from typing import Any, Optional
+import urllib.parse
 
 import docker
+import aiohttp as ah
+from database import Database
 
 from config import settings
 
 doc = docker.from_env()
 
 logger = logging.getLogger(__name__)
+
 
 async def run_cmd(cmd: str, env: dict[str, str], vols: dict[str, dict[str, str]]) -> str:
     """
@@ -34,14 +40,161 @@ async def run_cmd(cmd: str, env: dict[str, str], vols: dict[str, dict[str, str]]
     return out
 
 
-def get_remote_tags(image_ref: str):
+async def bg_update() -> None:
+    """
+    Background update task. Run periodically, or metadata about tags in the DB won't be correct.
+    Definitely run on startup; startup is when the bench format change will first be noticed.
+    """
+
+    image = settings.docker.container_ref
+
+    async with ah.ClientSession() as session:
+        # TODO: get_remote_tags is supposed to be paginated...
+        tags = await get_remote_tags(session, image)
+        new_versions: set[str] = set()
+        with Database() as db:
+            new_versions = db.pick_new_container_versions(tags)
+        for ver in new_versions:
+            rust_ver = await get_rust_version(image, ver)
+            bench_format, _stamp = ver.split(".")
+            with Database() as db:
+                # TODO: Figure out something to do with the bench_dir
+                db.insert_container_version(rust_ver.ver, ver, int(bench_format), b"")
+
+
+# --- Utils ---
+
+RustVersion = namedtuple("RustVersion", "ver hash date")
+
+
+async def get_rust_version(image: str, tag: str) -> RustVersion:
+    cmd = "rustc --version"
+    out = await run_cmd(cmd, {}, {})
+    _, ver, d = out.split(" ")
+    git_hash, dstamp = d.strip("()").split(" ")
+    return RustVersion(ver, git_hash, dstamp)
+
+
+API_URLs = {
+    "ghcr.io": "https://docker.pkg.github.com/v2",
+    "docker.io": "https://registry.hub.docker.com/v2",
+}
+
+AUTH_TOKENS: dict[str, str] = {}
+
+
+async def docker_hub_auth(session: ah.ClientSession, api_base: str) -> str:
+    """Returns a Bearer Token you can use with further Docker Hub API requests."""
+    if api_base in API_URLs:
+        # Callers are expected to delete items from AUTH_TOKENS when they get a 403.
+        return AUTH_TOKENS[api_base]
+    auth_url = "/".join([api_base, "v2/users/login"])
+    headers = {"Accept", "application/json"}
+    auth_body = {"username": "ferris-elf", "password": settings.docker_auth.token}
+    async with session.post(
+        auth_url, json=auth_body, raise_for_status=True, headers=headers
+    ) as response:
+        token = await response.text()
+        AUTH_TOKENS[api_base] = token
+        return "Bearer " + token
+
+
+def _parse_image_ref(image_ref: str) -> urllib.parse.ParseResult:
+    user_url = urllib.parse.urlparse(image_ref)
+
+    # The built-in urllib.parse seems to not understand no-scheme URLs.
+    if not user_url.scheme:
+        user_url = urllib.parse.urlparse("https://" + image_ref)
+
+    return user_url
+
+
+def _get_api_base(image_ref: str) -> str:
+    user_url = _parse_image_ref(image_ref)
+
+    # TODO: Find a way to do this that doesn't rely on lookup tables
+    api_base = API_URLs.get(user_url.netloc, None)
+    if api_base is None:
+        raise ValueError(f"Registry not supported: {image_ref}")
+
+    return api_base
+
+
+async def get_remote_tags(
+    session: ah.ClientSession, image_ref: str, auth_token: Optional[str] = None
+) -> list[str]:
     """Use the OCI Distribution API to get a list of tags for an image."""
-    raise NotImplementedError()
 
-def get_remote_manifest(image_ref: str, tag: str):
+    user_url = _parse_image_ref(image_ref)
+    api_base = _get_api_base(image_ref)
+
+    target_url = "/".join([api_base, user_url.path, "tags/list"])
+
+    auth_token = auth_token or await docker_hub_auth(session, api_base)
+    headers = {
+        "Authorization": auth_token,
+        "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+    }
+
+    async with session.get(target_url, headers=headers, raise_for_status=True) as response:
+        # FIXME: We should be expecting at least 404 & 403 here.
+        # TODO: This is actually a paginated API. Need `async yield` + multiple requests.
+        # Yeah, the typechecker has no way of confirming what's up.
+        # The remote API could change at any time. Such is life.
+        rv: list[str] = (await response.json()).tags
+        return rv
+
+
+async def get_remote_manifest(
+    session: ah.ClientSession, image_ref: str, tag: str, auth_token: Optional[str] = None
+) -> dict[str, Any]:
     """Retrieve the manifest for a specific tag of an image."""
-    raise NotImplementedError()
 
-def get_labels(image_manifest: str):
-    """Given a manifest, extract the labels from it."""
-    raise NotImplementedError
+    user_url = _parse_image_ref(image_ref)
+    api_base = _get_api_base(image_ref)
+
+    target_url = "/".join([api_base, user_url.path, "manifests", tag])
+
+    auth_token = auth_token or await docker_hub_auth(session, api_base)
+    headers = {
+        "Authorization": auth_token,
+        "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+    }
+
+    async with session.get(target_url, headers=headers, raise_for_status=True) as response:
+        # FIXME: We should be expecting at least 403.
+        rv: dict[str, Any] = await response.json()
+        return rv
+
+
+def get_digest_blob_hash(manifest: dict[str, Any]) -> Optional[str]:
+    """Get the digest's hash from a manifest. The hash can then be used to get the digest blob."""
+    rv: Optional[str] = manifest.get("config", {}).get("digest", None)
+    return rv
+
+
+async def get_remote_blob(
+    session: ah.ClientSession, image_ref: str, blob_hash: str, auth_token: Optional[str] = None
+) -> dict[str, Any]:
+    """Given a blob's hash, retrieve the contents of that blob."""
+    user_url = _parse_image_ref(image_ref)
+    api_base = _get_api_base(image_ref)
+
+    target_url = "/".join([api_base, user_url.path, "blobs", blob_hash])
+
+    auth_token = auth_token or await docker_hub_auth(session, api_base)
+    headers = {
+        "Authorization": auth_token,
+        "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+    }
+
+    async with session.get(target_url, headers=headers, raise_for_status=True) as response:
+        # FIXME: We should be expecting at least 403.
+        rv: dict[str, Any] = await response.json()
+        return rv
+
+
+def get_labels(digest_blob: dict[str, Any]) -> dict[str, str]:
+    """Given a digest blob, extract the labels from it."""
+    rv: dict[str, str] = digest_blob.get("config", {}).get("Labels")
+    return rv

--- a/runner.py
+++ b/runner.py
@@ -50,7 +50,7 @@ async def bg_update() -> None:
 
     async with ah.ClientSession() as session:
         # TODO: get_remote_tags is supposed to be paginated...
-        tags = await get_remote_tags(session, image)
+        tags = set(await get_remote_tags(session, image))
         new_versions: set[str] = set()
         with Database() as db:
             new_versions = db.pick_new_container_versions(tags)

--- a/runner.py
+++ b/runner.py
@@ -1,8 +1,7 @@
 import asyncio
-from collections import namedtuple
 import logging
 import functools
-from typing import Any, Optional
+from typing import Any, Optional, TypeAlias, NamedTuple
 import urllib.parse
 
 import docker
@@ -15,10 +14,11 @@ doc = docker.from_env()
 
 logger = logging.getLogger(__name__)
 
+VolumeDetails: TypeAlias = dict[str, str]
+VolumesInfo: TypeAlias = dict[str, VolumeDetails]
 
-async def run_cmd(
-    image: str, cmd: str, env: dict[str, str], vols: dict[str, dict[str, str]]
-) -> str:
+
+async def run_cmd(image: str, cmd: str, env: dict[str, str], vols: VolumesInfo) -> str:
     """
     Thin wrapper to simplify the Docker interface & provide secure defaults.
     """
@@ -80,7 +80,11 @@ async def bg_update() -> None:
 
 # --- Utils ---
 
-RustVersion = namedtuple("RustVersion", "ver hash date")
+
+class RustVersion(NamedTuple):
+    ver: str
+    hash: str
+    date: str
 
 
 async def get_rust_version(image: str, tag: str) -> RustVersion:

--- a/settings.toml
+++ b/settings.toml
@@ -9,7 +9,7 @@ rust_version_info = "latest stable for Docker containers"
 hw_info = "Benchmarks are run in a controlled sandbox with limited resources."
 
 [docker]
-container_ref = "ferris-elf-bencher"
+container_ref = "ghcr.io/proegssilb/ferris-elf-bencher"
 
 [aoc]
 inputs_dir = "inputs/"


### PR DESCRIPTION
I'm not sure how much of this code we still want, but it seems like we kinda need it for the state that #63 is in.

The lion's share of the work is integrating the bot with GitHub Container Registry. Would that there was a package to make this stuff easier, but I couldn't find a good option.

There is some extra code for labels. We don't need it for now, but at one point I thought we did, and we might still in the future as requirements change. So, it's there.