### PR TITLE
feat: Add submission moderation commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,5 +1,5 @@
 import asyncio
-from io import StringIO
+from io import BytesIO, StringIO
 import logging
 import sys
 from typing import Annotated, Any, Callable, Optional, Literal, ParamSpec, TypeVar
@@ -211,7 +211,9 @@ class ModCommands(commands.Cog):
         with Database() as db:
             results = db.get_user_submissions(lib.year(), day, part, user.id)
 
-        results.sort(key=(lambda r: r.average_time or Picoseconds(5e12)))  # 5s
+        results.sort(
+            key=(lambda r: r.average_time or Picoseconds(5e12))
+        )  # Default to 5s while sorting
         results = results[:10]
         results.sort(key=(lambda r: r.id))
 
@@ -219,11 +221,9 @@ class ModCommands(commands.Cog):
         for res in results:
             name = f"Submission_{res.id}.rs"
             desc = f"Submission {res.id} from user {user}"
-            file_handle = StringIO(res.code)
+            file_handle = BytesIO(res.code.encode("utf8"))
 
-            # Not sure whether the type on file_handle is specified incorrectly or this is an ugly hack.
-            # Either way, this is what works to get Discord to not open a file.
-            f = discord.File(file_handle, filename=name, description=desc)  # type: ignore[arg-type]
+            f = discord.File(file_handle, filename=name, description=desc)
             attachments.append(f)
 
         await interaction.edit_original_response(

--- a/bot.py
+++ b/bot.py
@@ -200,6 +200,14 @@ class ModCommands(commands.Cog):
     ) -> None:
         await interaction.response.send_message(content="Loading...")
 
+        logger.info(
+            "User %s requested submissions for user %s, day %s, part %s",
+            interaction.user,
+            user,
+            day,
+            part,
+        )
+
         with Database() as db:
             results = db.get_user_submissions(lib.year(), day, part, user.id)
 
@@ -235,6 +243,14 @@ class ModCommands(commands.Cog):
     ) -> None:
         await interaction.response.send_message(content="Loading...")
 
+        logger.info(
+            "User %s requested code for leaderboard entry (day %s, part %s, place %s)",
+            interaction.user,
+            day,
+            part,
+            place,
+        )
+
         with Database() as db:
             submisssions = db.get_lb_submissions(lib.year(), day, part)
 
@@ -266,6 +282,10 @@ class ModCommands(commands.Cog):
         interaction: discord.Interaction,  # type: ignore[type-arg]
         submission_id: Annotated[SubmissionId, int],
     ) -> None:
+        logger.info(
+            "User %s requested invalidation of submission %s", interaction.user, submission_id
+        )
+
         submission = lib.invalidate_submission(submission_id)
 
         user = self.bot.get_user(submission.user_id) or await self.bot.fetch_user(
@@ -273,6 +293,13 @@ class ModCommands(commands.Cog):
         )
 
         msg = f"Submission {submission_id} by {user} invalidated."
+
+        logger.info(
+            "Submission %s by user %s invalidated, as per request from %s",
+            submission_id,
+            user,
+            interaction.user,
+        )
 
         await interaction.response.send_message(content=msg)
 

--- a/bot.py
+++ b/bot.py
@@ -234,13 +234,13 @@ class ModCommands(commands.Cog):
         place: Optional[app_commands.Range[int, 1, 10]] = None,
     ) -> None:
         await interaction.response.send_message(content="Loading...")
-        
+
         with Database() as db:
             submisssions = db.get_lb_submissions(lib.year(), day, part)
 
         if place is not None:
             submisssions = [submisssions[place - 1]]
-        
+
         attachments = []
         for res in submisssions:
             user = self.bot.get_user(res.user_id) or await self.bot.fetch_user(res.user_id)
@@ -252,7 +252,7 @@ class ModCommands(commands.Cog):
             # Either way, this is what works to get Discord to not open a file.
             f = discord.File(file_handle, filename=name, description=desc)  # type: ignore[arg-type]
             attachments.append(f)
-        
+
         await interaction.edit_original_response(
             content=f"Leaderboard submissions on day {day}, part {part}:",
             attachments=attachments,

--- a/bot.py
+++ b/bot.py
@@ -51,8 +51,9 @@ class Commands(commands.Cog):
     def __init__(self, sbot: MyBot) -> None:
         self.bot = sbot
 
-    @commands.command()
     @commands.is_owner()
+    @commands.dm_only()
+    @commands.hybrid_command()
     async def sync(self, ctx: commands.Context[Any]) -> None:
         # sync slash commands
         # this is a separate command because rate limits
@@ -61,8 +62,8 @@ class Commands(commands.Cog):
 
     # intentionally did not use typing.Optional because dpy treats it differently and i dont want that behavior
     # type-ignore for mypy not understanding how to work with hybrid_command decorator
-    @commands.hybrid_command(aliases=["aoc", "lb"])  # type: ignore[arg-type]
-    async def best(
+    @commands.hybrid_command()  # type: ignore[arg-type]
+    async def leaderboard(
         self,
         ctx: commands.Context[Any],
         day: Annotated[Optional[AdventDay], commands.Range[int, 1, 25]] = None,
@@ -93,8 +94,37 @@ class Commands(commands.Cog):
         embed.set_footer(text=constants.LEADERBOARD_FOOTER)
         await ctx.reply(embed=embed)
 
+    # `aliases` argument doesn't work for the slash-cmd part, so do it manually.
+    @commands.hybrid_command()
+    async def lb(
+        self,
+        ctx: commands.Context[Any],
+        day: Annotated[Optional[AdventDay], commands.Range[int, 1, 25]] = None,
+        part: Annotated[Optional[Literal[1, 2]], Literal[1, 2]] = None,
+    ) -> None:
+        await self.best(ctx, day, part)
+    
+    @commands.hybrid_command()
+    async def best(
+        self,
+        ctx: commands.Context[Any],
+        day: Annotated[Optional[AdventDay], commands.Range[int, 1, 25]] = None,
+        part: Annotated[Optional[Literal[1, 2]], Literal[1, 2]] = None,
+    ) -> None:
+        await self.best(ctx, day, part)
+
+    @commands.hybrid_command()
+    async def aoc(
+        self,
+        ctx: commands.Context[Any],
+        day: Annotated[Optional[AdventDay], commands.Range[int, 1, 25]] = None,
+        part: Annotated[Optional[Literal[1, 2]], Literal[1, 2]] = None,
+    ) -> None:
+        await self.best(ctx, day, part)
+
     # i intentionally did not have the default behavior of automatically choosing part 1 because that's confusing
     # type-ignore for mypy not understanding how to work with hybrid_command decorator
+    @commands.dm_only()
     @commands.hybrid_command()  # type: ignore[arg-type]
     async def submit(
         self,

--- a/bot.py
+++ b/bot.py
@@ -51,7 +51,7 @@ class Commands(commands.Cog):
 
     @commands.is_owner()
     @commands.dm_only()
-    @commands.hybrid_command()
+    @commands.command()
     async def sync(self, ctx: commands.Context[Any]) -> None:
         # sync slash commands
         # this is a separate command because rate limits

--- a/bot.py
+++ b/bot.py
@@ -105,7 +105,7 @@ class Commands(commands.Cog):
         day: Annotated[Optional[AdventDay], commands.Range[int, 1, 25]] = None,
         part: Annotated[Optional[Literal[1, 2]], Literal[1, 2]] = None,
     ) -> None:
-        await self.best(ctx, day, part)  # type: ignore[arg-type]
+        await self.leaderboard(ctx, day, part)  # type: ignore[arg-type]
 
     @commands.hybrid_command()  # type: ignore[arg-type]
     async def best(
@@ -114,7 +114,7 @@ class Commands(commands.Cog):
         day: Annotated[Optional[AdventDay], commands.Range[int, 1, 25]] = None,
         part: Annotated[Optional[Literal[1, 2]], Literal[1, 2]] = None,
     ) -> None:
-        await self.best(ctx, day, part)  # type: ignore[arg-type]
+        await self.leaderboard(ctx, day, part)  # type: ignore[arg-type]
 
     @commands.hybrid_command()  # type: ignore[arg-type]
     async def aoc(
@@ -123,7 +123,7 @@ class Commands(commands.Cog):
         day: Annotated[Optional[AdventDay], commands.Range[int, 1, 25]] = None,
         part: Annotated[Optional[Literal[1, 2]], Literal[1, 2]] = None,
     ) -> None:
-        await self.best(ctx, day, part)  # type: ignore[arg-type]
+        await self.leaderboard(ctx, day, part)  # type: ignore[arg-type]
 
     # i intentionally did not have the default behavior of automatically choosing part 1 because that's confusing
     # type-ignore for mypy not understanding how to work with hybrid_command decorator
@@ -211,7 +211,7 @@ class ModCommands(commands.Cog):
         with Database() as db:
             results = db.get_user_submissions(lib.year(), day, part, user.id)
 
-        results.sort(key=(lambda r: r.average_time or Picoseconds(5e12)))
+        results.sort(key=(lambda r: r.average_time or Picoseconds(5e12)))  # 5s
         results = results[:10]
         results.sort(key=(lambda r: r.id))
 
@@ -221,7 +221,7 @@ class ModCommands(commands.Cog):
             desc = f"Submission {res.id} from user {user}"
             file_handle = StringIO(res.code)
 
-            # Not sure whether the type is specified incorrectly or this is an ugly hack.
+            # Not sure whether the type on file_handle is specified incorrectly or this is an ugly hack.
             # Either way, this is what works to get Discord to not open a file.
             f = discord.File(file_handle, filename=name, description=desc)  # type: ignore[arg-type]
             attachments.append(f)

--- a/bot.py
+++ b/bot.py
@@ -19,15 +19,13 @@ logger = logging.getLogger(__name__)
 
 
 class MyBot(commands.Bot):
-    __slots__ = ("queue", "db")
+    __slots__ = ("queue")
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.queue = asyncio.Queue[
             tuple[commands.Context[Any], Year, AdventDay, AdventPart, bytes]
         ]()
-        # this is unusued ??
-        self.db = Database()
 
     async def setup_hook(self) -> None:
         await asyncio.gather(bot.add_cog(Commands(bot)), bot.add_cog(ErrorHandlerCog(bot)))

--- a/bot.py
+++ b/bot.py
@@ -170,14 +170,17 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-def only_from_guilds(*servers: list[int]) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def only_from_guilds(*servers: int) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Add a check to make sure the command can only be run from one of a list of servers."""
 
     # The lazy return type is due to discord.py not being more specific in their return type.
     # `discord.Interaction` is currently a generic type, but is not documented that way.
 
+    # We shouldn't have to deal with `None` here, but you never know...
+    guild_set = frozenset(servers or [])
+
     def check_guild(itr: discord.Interaction) -> bool:  # type: ignore[type-arg]
-        return itr.guild_id in (servers or [])
+        return itr.guild_id in guild_set
 
     return app_commands.check(check_guild)
 

--- a/bot.py
+++ b/bot.py
@@ -12,7 +12,7 @@ from dynaconf import ValidationError
 import constants
 import lib
 from config import settings
-from database import AdventDay, AdventPart, Database, Picoseconds, Year
+from database import AdventDay, AdventPart, Database, Picoseconds, SubmissionId, Year
 from error_handler import ErrorHandlerCog
 from runner import bg_update
 
@@ -257,6 +257,24 @@ class ModCommands(commands.Cog):
             content=f"Leaderboard submissions on day {day}, part {part}:",
             attachments=attachments,
         )
+
+    @app_commands.command()
+    @app_commands.default_permissions(manage_messages=True)
+    @only_from_guilds(*settings.discord.management_servers)
+    async def invalidate_code(
+        self,
+        interaction: discord.Interaction,  # type: ignore[type-arg]
+        submission_id: Annotated[SubmissionId, int],
+    ) -> None:
+        submission = lib.invalidate_submission(submission_id)
+
+        user = self.bot.get_user(submission.user_id) or await self.bot.fetch_user(
+            submission.user_id
+        )
+
+        msg = f"Submission {submission_id} by {user} invalidated."
+
+        await interaction.response.send_message(content=msg)
 
 
 async def prefix(dbot: commands.Bot, message: discord.Message) -> list[str]:

--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ settings = Dynaconf(
         Validator("discord.support_info", must_exist=True),
         Validator("discord.rust_version_info", must_exist=True),
         Validator("discord.hw_info", must_exist=True),
+        Validator("discord.management_servers", must_exist=True, len_min=1),
         Validator("aoc.inputs_dir", must_exist=True),
         Validator("docker.container_ref", must_exist=True),
         Validator("aoc_auth.tokens", must_exist=True, len_min=1),

--- a/database.py
+++ b/database.py
@@ -503,7 +503,7 @@ class Database:
         self, year: Year, day: AdventDay, part: AdventPart, user_id: int, /
     ) -> list[Submission]:
         submissions = self._cursor.execute(
-            "SELECT submission_id FROM submissions WHERE (year = ? AND day_part = ? AND user = ?) ORDER BY submission_id",
+            "SELECT submission_id FROM submissions WHERE (year = ? AND day_part = ? AND user = ? AND valid = 1) ORDER BY submission_id",
             (year, pack_day_part(day, part), str(user_id)),
         )
 

--- a/database.py
+++ b/database.py
@@ -407,7 +407,11 @@ class Database:
         Flushes the best_runs table for a given user and year-day-part, used when inserting new entries or when marking submissions invalid
         """
         self._cursor.execute(
-            "REPLACE INTO best_runs "
+            "DELETE FROM best_runs WHERE (year = ? AND day_part = ? AND user = ?)",
+            (year, pack_day_part(day, part), user_id),
+        )
+        self._cursor.execute(
+            "INSERT INTO best_runs "
             + "SELECT user, year, day_part, MIN(average_time) AS best_time, submission_id AS run_id FROM submissions "
             + "WHERE (year = ? AND day_part = ? AND valid = 1 AND user = ?)",
             (year, pack_day_part(day, part), user_id),

--- a/database.py
+++ b/database.py
@@ -9,6 +9,7 @@ from typing import (
     NewType,
     Optional,
     Self,
+    Sequence,
     TypeAlias,
     TypeVar,
     cast,
@@ -557,8 +558,12 @@ class Database:
 
         return None
 
-    def get_submissions_by_ids(self, ids: tuple[SubmissionId, ...], /) -> list[Submission]:
+    def get_submissions_by_ids(self, ids: Sequence[SubmissionId], /) -> list[Submission]:
         """Retrieve fully-hydrated Submission objects for the specified Submission IDs"""
+
+        # People on Stack Overflow have had problems with fewer than two items with the
+        # IN clause. So deal with 0 and 1 seperately, and then sqlite's query parser can't
+        # cause problems.
         if len(ids) == 0:
             return []
         if len(ids) == 1:

--- a/lib.py
+++ b/lib.py
@@ -16,7 +16,17 @@ from discord.ext import commands
 
 from config import settings
 import constants
-from database import AdventDay, AdventPart, AocInput, Database, Picoseconds, SessionLabel, Year
+from database import (
+    AdventDay,
+    AdventPart,
+    AocInput,
+    Database,
+    Picoseconds,
+    SessionLabel,
+    Submission,
+    SubmissionId,
+    Year,
+)
 from runner import run_cmd
 
 logger = logging.getLogger(__name__)
@@ -320,6 +330,18 @@ def get_best_times(
         times2 = [(user, str(time)) for user, time in db.best_times(cur_year, day, 2)]
 
     return (times1, times2)
+
+
+def invalidate_submission(submission_id: SubmissionId) -> Submission:
+    """Mark a submission as invalid, and shouldn't be on the leaderboard."""
+    with Database() as db:
+        submission = db.get_submission_by_id(submission_id)
+        if submission is None:
+            logger.error("Asked to invalidate submission %s, but not found.", submission_id)
+            raise ValueError("Invalid submission.")
+        db.mark_submission_invalid(submission_id)
+
+    return submission
 
 
 def year() -> Year:

--- a/lib.py
+++ b/lib.py
@@ -338,7 +338,7 @@ def invalidate_submission(submission_id: SubmissionId) -> Submission:
         submission = db.get_submission_by_id(submission_id)
         if submission is None:
             logger.error("Asked to invalidate submission %s, but not found.", submission_id)
-            raise ValueError("Invalid submission.")
+            raise KeyError("Invalid submission.")
         db.mark_submission_invalid(submission_id)
 
     return submission

--- a/settings.toml
+++ b/settings.toml
@@ -4,6 +4,7 @@ dynaconf_merge = true
 filename = "database.db"
 
 [discord]
+management_servers = [273534239310479360, 1181719916559212545]
 support_info = "@format Ping <@{this.discord.owner_id}> for any support issues"
 rust_version_info = "latest stable for Docker containers"
 hw_info = "Benchmarks are run in a controlled sandbox with limited resources."


### PR DESCRIPTION
Fixes #26 .

- Add commands for viewing code for submissions by user and by leaderboard
- Add command for deleting submissions
- Add (required) config for "management servers"
- Clean up aliases for leaderboard command
- Add some more logging